### PR TITLE
feat: containerize api and app for self-hosting

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,34 @@
+# Dependencies & build output (regenerated inside the image)
+**/node_modules
+**/dist
+**/.next
+**/.turbo
+packages/db/src/generated
+
+# Local env files — never bake secrets into an image.
+# Runtime config is provided via docker-compose `env_file` / `--env-file`.
+**/.env
+**/.env.*
+!**/.env.example
+
+# VCS, tooling, editor, OS cruft
+.git
+.github
+.changeset
+.codex
+.claude
+.cursor
+**/.vscode
+**/.idea
+**/.DS_Store
+
+# Logs & misc
+logs
+**/logs
+*.log
+**/*.tsbuildinfo
+
+# Docker artifacts themselves
+**/Dockerfile
+.dockerignore
+docker-compose*.yml

--- a/.env.example
+++ b/.env.example
@@ -1,28 +1,64 @@
-APP_URL="http://localhost:5183"
+# OpenAds environment — copy to `.env` and fill in values.
+# Serves both `bun run dev` and the Docker stack (docker-compose.yml).
+#
+# Docker note: compose wires Postgres + Redis automatically, so for the bundled
+# stack you only need the secrets below — DATABASE_URL and REDIS_REST_URL are
+# ignored (compose overrides them). See docs/self-hosting.md.
+
+# ---- Public URLs ----
+# Values target the Docker stack. For local `bun run dev`, use http://localhost:5183.
+APP_URL="http://localhost:8080"
 API_URL="http://localhost:3001"
 
-# Database
+# ---- Dashboard (Vite — baked into the bundle at build time) ----
+VITE_BASE_URL="http://localhost:8080"
+VITE_API_URL="http://localhost:3001"
+# Optional integrations — leave empty to disable.
+VITE_OPENPANEL_CLIENT_ID=""
+VITE_COSSISTANT_PUBLIC_KEY=""
+
+# ---- Database ----
+# Docker: auto-wired to the bundled Postgres (ignored). Dev: your Postgres URL.
 DATABASE_URL=""
 
-# Auth
-BETTER_AUTH_SECRET=""
-BETTER_AUTH_URL="http://localhost:5183"
-
+# ---- Auth ----
+BETTER_AUTH_SECRET=""                       # openssl rand -base64 32
+BETTER_AUTH_URL="http://localhost:8080"     # dev: http://localhost:5183
 GOOGLE_CLIENT_ID=""
 GOOGLE_CLIENT_SECRET=""
 
-# Redis
+# ---- Redis ----
+# Docker: auto-wired to the bundled Redis proxy (URL ignored); only the token is
+# used and must match compose's SRH_TOKEN (default "openads"). Dev: use Upstash.
 REDIS_REST_URL="https://xyz.upstash.io"
-REDIS_REST_TOKEN="xyz"
+REDIS_REST_TOKEN="openads"
 
-# Stripe
-STRIPE_SECRET_KEY="xyz"
-STRIPE_CONNECT_CLIENT_ID="ca_xyz"
-STRIPE_CONNECT_WEBHOOK_SECRET="whsec_xyz"
+# ---- Stripe (Connect platform account) ----
+STRIPE_SECRET_KEY=""
+STRIPE_CONNECT_CLIENT_ID="ca_xxx"
+STRIPE_CONNECT_WEBHOOK_SECRET="whsec_xxx"
 STRIPE_PLATFORM_FEE_PERCENT="0"
 
-# Email (AutoSend)
+# ---- Email (AutoSend) ----
 AUTOSEND_API_KEY=""
 AUTOSEND_FROM_EMAIL=""
 AUTOSEND_FROM_NAME="OpenAds"
 AUTOSEND_WAITLIST_LIST_ID=""
+
+# ---- Object storage (S3 / Cloudflare R2 / MinIO) ----
+S3_REGION="auto"
+S3_ACCESS_KEY_ID=""
+S3_SECRET_ACCESS_KEY=""
+S3_BUCKET="openads"
+# Optional — keep these COMMENTED OUT unless used. An empty value (e.g.
+# S3_ENDPOINT="") fails validation; leave the line out entirely instead.
+# S3_ENDPOINT=https://<account>.r2.cloudflarestorage.com   # R2/MinIO; unset = AWS S3
+# S3_PUBLIC_URL=https://cdn.example.com                     # public base URL for objects
+# S3_FORCE_PATH_STYLE=true                                  # required for MinIO
+
+# ---- Docker overrides (optional; compose has sensible defaults) ----
+# APP_PORT=8080
+# API_PORT=3001
+# POSTGRES_USER=openads
+# POSTGRES_PASSWORD=openads
+# POSTGRES_DB=openads

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,43 @@
+# syntax=docker/dockerfile:1.7-labs
+#
+# OpenAds API (Hono on Bun). Build from the MONOREPO ROOT (workspace deps):
+#   docker build -f apps/api/Dockerfile -t openads-api .
+# Needs BuildKit (Docker 23+) for `COPY --parents`.
+
+# ---- deps: install workspace + generate Prisma client ----
+FROM oven/bun:1.3.14-slim AS deps
+WORKDIR /app
+
+# Prisma's schema engine needs openssl at generate time.
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends openssl ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+
+# Manifests first so `bun install` caches until a manifest/lockfile changes.
+COPY --parents package.json bun.lock apps/*/package.json packages/*/package.json ./
+# Schema + config for the @openads/db postinstall (`prisma generate`).
+COPY packages/db/prisma ./packages/db/prisma
+COPY packages/db/prisma.config.ts ./packages/db/prisma.config.ts
+
+# Frozen: fail rather than silently mutate bun.lock (supply-chain safety).
+# The pinned bun base must match the version that wrote the lockfile.
+RUN bun install --frozen-lockfile
+
+# ---- api: overlay source and run ----
+FROM deps AS api
+WORKDIR /app
+# node_modules + generated client inherited from deps; source can't clobber them.
+COPY . .
+
+ENV NODE_ENV=production \
+    PORT=3001
+EXPOSE 3001
+
+# Bun auto-serves a default export of `{ port, fetch }`. Run from apps/api so
+# the `~/*` tsconfig alias resolves.
+WORKDIR /app/apps/api
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 \
+  CMD bun -e "fetch('http://127.0.0.1:'+(process.env.PORT||3001)+'/').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
+CMD ["bun", "run", "src/index.ts"]

--- a/apps/app/Dockerfile
+++ b/apps/app/Dockerfile
@@ -1,0 +1,46 @@
+# syntax=docker/dockerfile:1.7-labs
+#
+# OpenAds dashboard (Vite SPA → nginx). Build from the MONOREPO ROOT:
+#   docker build -f apps/app/Dockerfile -t openads-app \
+#     --build-arg VITE_API_URL=https://api.example.com \
+#     --build-arg VITE_BASE_URL=https://app.example.com .
+# VITE_* values are BAKED INTO THE BUNDLE at build time — rebuild to change them.
+# Needs BuildKit (Docker 23+) for `COPY --parents`.
+
+# ---- deps: install workspace + generate Prisma client ----
+FROM oven/bun:1.3.14-slim AS deps
+WORKDIR /app
+RUN apt-get update \
+  && apt-get install -y --no-install-recommends openssl ca-certificates \
+  && rm -rf /var/lib/apt/lists/*
+COPY --parents package.json bun.lock apps/*/package.json packages/*/package.json ./
+COPY packages/db/prisma ./packages/db/prisma
+COPY packages/db/prisma.config.ts ./packages/db/prisma.config.ts
+RUN bun install --frozen-lockfile
+
+# ---- build: produce the static bundle ----
+FROM deps AS build
+WORKDIR /app
+COPY . .
+
+# Public client config. Defaults target the docker-compose stack. The two
+# analytics keys are optional — leave empty and both features no-op.
+ARG VITE_API_URL=http://localhost:3001
+ARG VITE_BASE_URL=http://localhost:8080
+ARG VITE_OPENPANEL_CLIENT_ID=
+ARG VITE_COSSISTANT_PUBLIC_KEY=
+ENV VITE_API_URL=$VITE_API_URL \
+    VITE_BASE_URL=$VITE_BASE_URL \
+    VITE_OPENPANEL_CLIENT_ID=$VITE_OPENPANEL_CLIENT_ID \
+    VITE_COSSISTANT_PUBLIC_KEY=$VITE_COSSISTANT_PUBLIC_KEY
+
+WORKDIR /app/apps/app
+RUN bun run build
+
+# ---- runtime: static server with SPA fallback ----
+FROM nginx:1.27-alpine AS app
+COPY apps/app/docker/nginx.conf /etc/nginx/conf.d/default.conf
+COPY --from=build /app/apps/app/dist /usr/share/nginx/html
+EXPOSE 80
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+  CMD wget -q --spider http://127.0.0.1/ || exit 1

--- a/apps/app/docker/nginx.conf
+++ b/apps/app/docker/nginx.conf
@@ -1,0 +1,33 @@
+# Static-file serving for the OpenAds dashboard SPA.
+server {
+  listen 80;
+  server_name _;
+  root /usr/share/nginx/html;
+  index index.html;
+
+  # Don't leak the nginx version.
+  server_tokens off;
+
+  # Compress text assets on the fly.
+  gzip on;
+  gzip_vary on;
+  gzip_min_length 1024;
+  gzip_types text/plain text/css application/javascript application/json image/svg+xml;
+
+  # Vite emits content-hashed files under /assets — safe to cache forever.
+  location /assets/ {
+    expires 1y;
+    add_header Cache-Control "public, immutable";
+    try_files $uri =404;
+  }
+
+  # The HTML shell must never be cached, or clients pin a stale bundle reference.
+  location = /index.html {
+    add_header Cache-Control "no-cache, no-store, must-revalidate";
+  }
+
+  # SPA fallback: every unknown path is handled by the client-side router.
+  location / {
+    try_files $uri $uri/ /index.html;
+  }
+}

--- a/apps/app/src/env.ts
+++ b/apps/app/src/env.ts
@@ -10,8 +10,10 @@ export const env = createEnv({
   client: {
     VITE_BASE_URL: z.string(),
     VITE_API_URL: z.string(),
-    VITE_OPENPANEL_CLIENT_ID: z.string().min(1),
-    VITE_COSSISTANT_PUBLIC_KEY: z.string().min(1),
+    // Optional third-party integrations (product analytics + support widget).
+    // Omit them for a self-hosted build — both features no-op when unset.
+    VITE_OPENPANEL_CLIENT_ID: z.string().min(1).optional(),
+    VITE_COSSISTANT_PUBLIC_KEY: z.string().min(1).optional(),
   },
 
   /**

--- a/apps/app/src/routes/__root.tsx
+++ b/apps/app/src/routes/__root.tsx
@@ -42,7 +42,7 @@ function RootComponent() {
       <TooltipProvider delayDuration={100}>
         <Outlet />
 
-        <Analytics clientId={env.VITE_OPENPANEL_CLIENT_ID} />
+        {env.VITE_OPENPANEL_CLIENT_ID && <Analytics clientId={env.VITE_OPENPANEL_CLIENT_ID} />}
         <Toaster />
       </TooltipProvider>
     </SupportProvider>

--- a/bun.lock
+++ b/bun.lock
@@ -485,21 +485,21 @@
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
-    "@better-auth/core": ["@better-auth/core@1.6.11", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.39.0", "@standard-schema/spec": "^1.1.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/utils": "0.4.0", "@better-fetch/fetch": "1.1.21", "@cloudflare/workers-types": ">=4", "@opentelemetry/api": "^1.9.0", "better-call": "1.3.5", "jose": "^6.1.0", "kysely": "^0.28.5", "nanostores": "^1.0.1" }, "optionalPeers": ["@cloudflare/workers-types", "@opentelemetry/api"] }, "sha512-LrwidLCV8azdMGjvtwp30nj9tIv1BwI3VhtC0UaGSjQkAVWw4bN42I8qwbxRziPeSQoj+zUVkOpxZzAWBDARtQ=="],
+    "@better-auth/core": ["@better-auth/core@1.6.13", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.39.0", "@standard-schema/spec": "^1.1.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/utils": "0.4.1", "@better-fetch/fetch": "1.1.21", "@cloudflare/workers-types": ">=4", "@opentelemetry/api": "^1.9.0", "better-call": "1.3.5", "jose": "^6.1.0", "kysely": "^0.28.5 || ^0.29.0", "nanostores": "^1.0.1" }, "optionalPeers": ["@cloudflare/workers-types", "@opentelemetry/api"] }, "sha512-3YNjiLUmlNt5T9qQ/weu0tZgGgXDSYax4EE/uLUBIBBGtQI9Q3KdEnO6tfPgDedborcSE1bIspuAIaHpaHwxZQ=="],
 
-    "@better-auth/drizzle-adapter": ["@better-auth/drizzle-adapter@1.6.11", "", { "peerDependencies": { "@better-auth/core": "^1.6.11", "@better-auth/utils": "0.4.0", "drizzle-orm": "^0.45.2" }, "optionalPeers": ["drizzle-orm"] }, "sha512-4jpkETIGZOHCf7BK4jnu22fdN6jjomH0/HhEzkaWy3+Eppi5PYlHTF/460jrTmA3Xc+Vqwp9t282ymHiEPypGw=="],
+    "@better-auth/drizzle-adapter": ["@better-auth/drizzle-adapter@1.6.13", "", { "peerDependencies": { "@better-auth/core": "^1.6.13", "@better-auth/utils": "0.4.1", "drizzle-orm": "^0.45.2" }, "optionalPeers": ["drizzle-orm"] }, "sha512-0V6e+e7TnIZZDjhQP/tvAberSrdrf5yfbDSx5oDFsfI5MCh2ATvbuTPNxGWbLdbGnUYfbX4K9FZwzKMj8RpLmg=="],
 
-    "@better-auth/kysely-adapter": ["@better-auth/kysely-adapter@1.6.11", "", { "peerDependencies": { "@better-auth/core": "^1.6.11", "@better-auth/utils": "0.4.0", "kysely": "^0.28.17" }, "optionalPeers": ["kysely"] }, "sha512-/g8M9RfIjdcZDnbstSUvQiINkvdNlCeZr248zwqx2/PVksQI1MhQofbzUn3RnQnbPKp0EPwpX/dR3oudRFenUg=="],
+    "@better-auth/kysely-adapter": ["@better-auth/kysely-adapter@1.6.13", "", { "peerDependencies": { "@better-auth/core": "^1.6.13", "@better-auth/utils": "0.4.1", "kysely": "^0.28.17 || ^0.29.0" }, "optionalPeers": ["kysely"] }, "sha512-r+TeBL9dJecuCaSMqL3106qwaXYL3GAkoJDfmtbZ2eZ/Ejr9xVj5msJnSULb0ZqyQ1g5SCbnM39WZaCOFirziQ=="],
 
-    "@better-auth/memory-adapter": ["@better-auth/memory-adapter@1.6.11", "", { "peerDependencies": { "@better-auth/core": "^1.6.11", "@better-auth/utils": "0.4.0" } }, "sha512-hpdfw0BBf8MuzLkIdmbcUZICbY9r/bhLO2RxSnkzT5+/O+0I0u2I8+m0YUP7vNllP/ZCKASHOYgXPLO75Z0f9Q=="],
+    "@better-auth/memory-adapter": ["@better-auth/memory-adapter@1.6.13", "", { "peerDependencies": { "@better-auth/core": "^1.6.13", "@better-auth/utils": "0.4.1" } }, "sha512-upmNncEwm9Q0MpWLVOdx9Pe3fU/aqobO80zwI+WVCavxmL59SufW5Ud7194/J5ushw4Dd52XNn0XWPJT1ZUThg=="],
 
-    "@better-auth/mongo-adapter": ["@better-auth/mongo-adapter@1.6.11", "", { "peerDependencies": { "@better-auth/core": "^1.6.11", "@better-auth/utils": "0.4.0", "mongodb": "^6.0.0 || ^7.0.0" }, "optionalPeers": ["mongodb"] }, "sha512-3Tor8rSv8vSEIMEaV2PFpPEuVhqc1gNoZ6eGvoh3LwExXXuj8madew6ob+H1pH7Aphn3Ar5PQ08AguT8TbwFAA=="],
+    "@better-auth/mongo-adapter": ["@better-auth/mongo-adapter@1.6.13", "", { "peerDependencies": { "@better-auth/core": "^1.6.13", "@better-auth/utils": "0.4.1", "mongodb": "^6.0.0 || ^7.0.0" }, "optionalPeers": ["mongodb"] }, "sha512-u0g5KThZQInx4QxsaXDJ+Yg5A9z/ia/3EBwi+gI7+kSTKkeT9PZZ6J+erwJ5Sh4d0JUQsEX2DX2YRsg/mYnXWQ=="],
 
-    "@better-auth/prisma-adapter": ["@better-auth/prisma-adapter@1.6.11", "", { "peerDependencies": { "@better-auth/core": "^1.6.11", "@better-auth/utils": "0.4.0", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@prisma/client", "prisma"] }, "sha512-Pw+7q7zTp+VSci1V+CYMvuxIbAeVMZLe4lRo46LJoAKMHfjFl5T/ycsyFvWs/DkWC7n9gZZzRDEbHp0I5FiKKw=="],
+    "@better-auth/prisma-adapter": ["@better-auth/prisma-adapter@1.6.13", "", { "peerDependencies": { "@better-auth/core": "^1.6.13", "@better-auth/utils": "0.4.1", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@prisma/client", "prisma"] }, "sha512-gjmUIdqmxWb4WoNEN5rTQYQli6A9fPopAaVDiLh/gwO3ET10/PuOEwfESePEwUbArlKLLK3hPEWWe0RBojyxgQ=="],
 
-    "@better-auth/telemetry": ["@better-auth/telemetry@1.6.11", "", { "peerDependencies": { "@better-auth/core": "^1.6.11", "@better-auth/utils": "0.4.0", "@better-fetch/fetch": "1.1.21" } }, "sha512-hsjDHc8MZbm6/AHeNdtywrWedXevnBjmdvnHTcZub+rTVjOv+Td0roI8USKuC6uUibmrl//2rJfVCsGbopihNA=="],
+    "@better-auth/telemetry": ["@better-auth/telemetry@1.6.13", "", { "peerDependencies": { "@better-auth/core": "^1.6.13", "@better-auth/utils": "0.4.1", "@better-fetch/fetch": "1.1.21" } }, "sha512-CXfPPL55mZrGH1FUhZOw9REp2WRJoVjCh9egn+cIx3ReB/OnPz+eHSRft/IVLD2PQyP1FNr1Au89SXd2oPBUPg=="],
 
-    "@better-auth/utils": ["@better-auth/utils@0.4.0", "", { "dependencies": { "@noble/hashes": "^2.0.1" } }, "sha512-RpMtLUIQAEWMgdPLNVbIF5ON2mm+CH0U3rCdUCU1VyeAUui4m38DyK7/aXMLZov2YDjG684pS1D0MBllrmgjQA=="],
+    "@better-auth/utils": ["@better-auth/utils@0.4.1", "", { "dependencies": { "@noble/hashes": "^2.0.1" } }, "sha512-SZBPRPF3z0nBvE5ygOkxae35wnnXPRShmqFo78S+qslLeFoPu/pMgnXAuNKFMMybac3tiLaVg1e3MQW5MC+1iA=="],
 
     "@better-fetch/fetch": ["@better-fetch/fetch@1.1.21", "", {}, "sha512-/ImESw0sskqlVR94jB+5+Pxjf+xBwDZF/N5+y2/q4EqD7IARUTSpPfIo8uf39SYpCxyOCtbyYpUrZ3F/k0zT4A=="],
 
@@ -1127,7 +1127,7 @@
 
     "@react-email/render": ["@react-email/render@2.0.8", "", { "dependencies": { "html-to-text": "^9.0.5", "prettier": "^3.5.3" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc" } }, "sha512-5udvVr3U/WuGJZfLdLBOhkzrqRWd2Q5ZYmF7ppcy7FzWcwgshdqLMNqJOXcVzAXJXg/2bm7D+WGJzTtZOZMQnQ=="],
 
-    "@react-email/ui": ["@react-email/ui@6.1.5", "", { "dependencies": { "esbuild": "0.28.0", "next": "16.2.6" } }, "sha512-IJYZFEk3+VjM0hoPXXIiarps1MNOopQgycKMYzhG1iRHut32JKFMt9J0KFu7qmif5wpbGGxv6MhurdW3MG0WEA=="],
+    "@react-email/ui": ["@react-email/ui@6.5.0", "", { "dependencies": { "esbuild": "0.28.0", "next": "16.2.6" } }, "sha512-WWPwCW5B0ouZ0GFtpKJLF2DBptJannXUO1VOncOIg5WsTJQ/4tEnbf300i4vWFnzI83L4n3ObfEods75cOsp3w=="],
 
     "@reduxjs/toolkit": ["@reduxjs/toolkit@2.11.2", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "@standard-schema/utils": "^0.3.0", "immer": "^11.0.0", "redux": "^5.0.1", "redux-thunk": "^3.1.0", "reselect": "^5.1.0" }, "peerDependencies": { "react": "^16.9.0 || ^17.0.0 || ^18 || ^19", "react-redux": "^7.2.1 || ^8.1.3 || ^9.0.0" }, "optionalPeers": ["react", "react-redux"] }, "sha512-Kd6kAHTA6/nUpp8mySPqj3en3dm0tdMIgbttnQ1xFMVpufoj+ADi8pXLBsd4xzTRHQa7t/Jv8W5UnCuW4kuWMQ=="],
 
@@ -1385,7 +1385,7 @@
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.20", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ=="],
 
-    "better-auth": ["better-auth@1.6.11", "", { "dependencies": { "@better-auth/core": "1.6.11", "@better-auth/drizzle-adapter": "1.6.11", "@better-auth/kysely-adapter": "1.6.11", "@better-auth/memory-adapter": "1.6.11", "@better-auth/mongo-adapter": "1.6.11", "@better-auth/prisma-adapter": "1.6.11", "@better-auth/telemetry": "1.6.11", "@better-auth/utils": "0.4.0", "@better-fetch/fetch": "1.1.21", "@noble/ciphers": "^2.1.1", "@noble/hashes": "^2.0.1", "better-call": "1.3.5", "defu": "^6.1.4", "jose": "^6.1.3", "kysely": "^0.28.17", "nanostores": "^1.1.1", "zod": "^4.3.6" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4", "drizzle-orm": "^0.45.2", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-Wwt6+q07dwIhsp6XiM7L1qSXVUWBEtNl+eZvwM778CguFqDZFBN9Pt6LtFaHl55t8Z+Zc//5kxcbgDY8/79vFQ=="],
+    "better-auth": ["better-auth@1.6.13", "", { "dependencies": { "@better-auth/core": "1.6.13", "@better-auth/drizzle-adapter": "1.6.13", "@better-auth/kysely-adapter": "1.6.13", "@better-auth/memory-adapter": "1.6.13", "@better-auth/mongo-adapter": "1.6.13", "@better-auth/prisma-adapter": "1.6.13", "@better-auth/telemetry": "1.6.13", "@better-auth/utils": "0.4.1", "@better-fetch/fetch": "1.1.21", "@noble/ciphers": "^2.1.1", "@noble/hashes": "^2.0.1", "better-call": "1.3.5", "defu": "^6.1.4", "jose": "^6.1.3", "kysely": "^0.28.17 || ^0.29.0", "nanostores": "^1.1.1", "zod": "^4.3.6" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4", "drizzle-orm": "^0.45.2", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-jn8ATnGWDzMwpO4a/3iyW1/RayOF/aoPQOfAeqyCVnQCdqkaONVas9CjbY6PovMsTMa/MG+GRABySfzqtj5J/g=="],
 
     "better-call": ["better-call@1.3.5", "", { "dependencies": { "@better-auth/utils": "^0.4.0", "@better-fetch/fetch": "^1.1.21", "rou3": "^0.7.12", "set-cookie-parser": "^3.0.1" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-kOFJkBP7utAQLEYrobZm3vkTH8mXq5GNgvjc5/XEST1ilVHaxXUXfeDeFlqoETMtyqS4+3/h4ONX2i++ebZrvA=="],
 
@@ -2015,7 +2015,7 @@
 
     "react-dom": ["react-dom@19.2.6", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.6" } }, "sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g=="],
 
-    "react-email": ["react-email@6.1.5", "", { "dependencies": { "@babel/parser": "7.27.0", "@babel/traverse": "7.27.0", "@react-email/render": ">=2.0.8", "chokidar": "^4.0.3", "commander": "^13.0.0", "conf": "^15.0.2", "css-tree": "3.2.1", "debounce": "^2.0.0", "esbuild": "^0.28.0", "glob": "^13.0.6", "jiti": "2.4.2", "log-symbols": "^7.0.0", "marked": "^15.0.12", "mime-types": "^3.0.0", "normalize-path": "^3.0.0", "nypm": "0.6.6", "picospinner": "^3.0.0", "prismjs": "^1.30.0", "prompts": "2.4.2", "socket.io": "^4.8.1", "tailwindcss": "^4.1.18", "tsconfig-paths": "4.2.0" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc" }, "bin": { "email": "./dist/cli/index.mjs" } }, "sha512-f4I7Y+9kEMjALvcL5dn1TAsDJG7VgksrcR4x9PMQiaCCud4iUefJMBQAcOhvoBpk1k75lGhR/p75d7WMF24PfA=="],
+    "react-email": ["react-email@6.5.0", "", { "dependencies": { "@babel/parser": "7.27.0", "@babel/traverse": "7.27.0", "@react-email/render": ">=2.0.8", "chokidar": "^4.0.3", "commander": "^13.0.0", "conf": "^15.0.2", "css-tree": "3.2.1", "debounce": "^2.0.0", "esbuild": "^0.28.0", "glob": "^13.0.6", "jiti": "2.4.2", "log-symbols": "^7.0.0", "marked": "^15.0.12", "mime-types": "^3.0.0", "normalize-path": "^3.0.0", "nypm": "0.6.6", "picospinner": "^3.0.0", "prismjs": "^1.30.0", "prompts": "2.4.2", "socket.io": "^4.8.1", "tailwindcss": "^4.1.18", "tsconfig-paths": "4.2.0" }, "peerDependencies": { "react": "^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^18.0 || ^19.0 || ^19.0.0-rc" }, "bin": { "email": "./dist/cli/index.mjs" } }, "sha512-WrJ+XPW87O1dabF4RJNGnTr7VTGsNa+BlMiinAZdH5fg8Kepwk++ZzX+LEieTlk+a3r13TaTJ4DfI9gv++y02g=="],
 
     "react-hook-form": ["react-hook-form@7.75.0", "", { "peerDependencies": { "react": "^16.8.0 || ^17 || ^18 || ^19" } }, "sha512-Ovv94H+0p3sJ7B9B5QxPuCP1u8V/cHuVGyH55cSwodYDtoJwK+fqk3vjfIgSX59I2U/bU4z0nRJ9HMLpNiWEmw=="],
 
@@ -2297,8 +2297,6 @@
 
     "@babel/traverse/@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
 
-    "@better-auth/core/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
-
     "@changesets/changelog-github/dotenv": ["dotenv@8.6.0", "", {}, "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g=="],
 
     "@cossistant/core/nanoid": ["nanoid@5.1.9", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-ZUvP7KeBLe3OZ1ypw6dI/TzYJuvHP77IM4Ry73waSQTLn8/g8rpdjfyVAh7t1/+FjBtG4lCP42MEbDxOsRpBMw=="],
@@ -2377,7 +2375,7 @@
 
     "babel-dead-code-elimination/@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
 
-    "better-auth/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
+    "better-call/@better-auth/utils": ["@better-auth/utils@0.4.0", "", { "dependencies": { "@noble/hashes": "^2.0.1" } }, "sha512-RpMtLUIQAEWMgdPLNVbIF5ON2mm+CH0U3rCdUCU1VyeAUui4m38DyK7/aXMLZov2YDjG684pS1D0MBllrmgjQA=="],
 
     "bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,149 @@
+name: openads
+
+# Self-hostable OpenAds stack. Object storage is BYO (S3/R2) or the opt-in
+# `storage` profile below. See docs/self-hosting.md.
+#   cp .env.example .env   # fill in secrets
+#   docker compose up -d --build
+# Dashboard → http://localhost:8080   API → http://localhost:3001
+
+services:
+  postgres:
+    image: postgres:17-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-openads}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-openads}
+      POSTGRES_DB: ${POSTGRES_DB:-openads}
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
+    # No host port: the DB is only reached over the compose network. For host
+    # psql access use `docker compose exec postgres psql -U openads`.
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-openads} -d ${POSTGRES_DB:-openads}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: ["redis-server", "--save", "60", "1", "--appendonly", "no"]
+    volumes:
+      - redis-data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  # Upstash REST shim in front of Redis (the app uses the Upstash client).
+  serverless-redis-http:
+    image: hiett/serverless-redis-http:latest
+    restart: unless-stopped
+    environment:
+      SRH_MODE: env
+      SRH_TOKEN: ${REDIS_REST_TOKEN:-openads}
+      SRH_CONNECTION_STRING: redis://redis:6379
+    depends_on:
+      redis:
+        condition: service_healthy
+
+  # One-shot schema sync. Swap to `prisma migrate deploy` once migrations land.
+  migrate:
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
+    working_dir: /app/packages/db
+    # Client is already generated in the image; Prisma 7 dropped --skip-generate.
+    command: ["bunx", "prisma", "db", "push"]
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER:-openads}:${POSTGRES_PASSWORD:-openads}@postgres:5432/${POSTGRES_DB:-openads}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    restart: "no"
+
+  api:
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
+    restart: unless-stopped
+    # Secrets (auth, Stripe, AutoSend, S3, Google) come from .env. The infra
+    # below is wired by compose, so .env never needs DB/Redis values.
+    env_file: .env
+    environment:
+      NODE_ENV: production
+      PORT: 3001
+      APP_URL: ${APP_URL:-http://localhost:8080}
+      API_URL: ${API_URL:-http://localhost:3001}
+      BETTER_AUTH_URL: ${BETTER_AUTH_URL:-http://localhost:8080}
+      DATABASE_URL: postgresql://${POSTGRES_USER:-openads}:${POSTGRES_PASSWORD:-openads}@postgres:5432/${POSTGRES_DB:-openads}
+      REDIS_REST_URL: http://serverless-redis-http:80
+      REDIS_REST_TOKEN: ${REDIS_REST_TOKEN:-openads}
+    ports:
+      - "${API_PORT:-3001}:3001"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      serverless-redis-http:
+        condition: service_started
+      migrate:
+        condition: service_completed_successfully
+
+  app:
+    build:
+      context: .
+      dockerfile: apps/app/Dockerfile
+      args:
+        VITE_API_URL: ${VITE_API_URL:-http://localhost:3001}
+        VITE_BASE_URL: ${VITE_BASE_URL:-http://localhost:8080}
+        VITE_OPENPANEL_CLIENT_ID: ${VITE_OPENPANEL_CLIENT_ID:-}
+        VITE_COSSISTANT_PUBLIC_KEY: ${VITE_COSSISTANT_PUBLIC_KEY:-}
+    restart: unless-stopped
+    ports:
+      - "${APP_PORT:-8080}:80"
+    depends_on:
+      - api
+
+  # Optional self-hosted storage:  docker compose --profile storage up -d --build
+  # On localhost, S3_ENDPOINT must be reachable by both browser and API for
+  # presigned uploads — see docs/self-hosting.md. R2/S3 is simpler.
+  minio:
+    image: minio/minio:latest
+    profiles: ["storage"]
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${S3_ACCESS_KEY_ID:-openads}
+      MINIO_ROOT_PASSWORD: ${S3_SECRET_ACCESS_KEY:-openads-secret}
+    volumes:
+      - minio-data:/data
+    # Loopback-only: never expose object storage or its admin console to the
+    # network. For a real deployment, front it with your reverse proxy/domain.
+    ports:
+      - "127.0.0.1:${MINIO_PORT:-9000}:9000"
+      - "127.0.0.1:${MINIO_CONSOLE_PORT:-9001}:9001"
+
+  minio-init:
+    image: minio/mc:latest
+    profiles: ["storage"]
+    restart: "no"
+    depends_on:
+      minio:
+        condition: service_started
+    # Public-read download is intentional: this bucket holds ad creative
+    # (banners/images) that render on third-party publisher sites via plain
+    # URLs. Uploads are presigned (write stays private). Keep this bucket
+    # dedicated to public ad assets — don't store anything sensitive in it.
+    entrypoint: >
+      sh -c "
+      until mc alias set local http://minio:9000 $${S3_ACCESS_KEY_ID:-openads} $${S3_SECRET_ACCESS_KEY:-openads-secret}; do echo 'waiting for minio...'; sleep 1; done &&
+      mc mb -p local/$${S3_BUCKET:-openads} &&
+      mc anonymous set download local/$${S3_BUCKET:-openads} &&
+      echo 'minio bucket ready'
+      "
+
+volumes:
+  postgres-data:
+  redis-data:
+  minio-data:

--- a/docs/self-hosting.md
+++ b/docs/self-hosting.md
@@ -1,0 +1,104 @@
+# Self-hosting OpenAds
+
+OpenAds ships as Docker images for the two runtime apps:
+
+- **`apps/api`** — the Hono/Bun API (RPC at `/rpc`, public REST + OpenAPI at `/v1`, Stripe webhooks, auth). This is what the `@openads/sdk` / `@openads/react` clients call.
+- **`apps/app`** — the publisher/advertiser dashboard (a Vite SPA served by nginx).
+
+The `docker-compose.yml` at the repo root wires both together with Postgres and Redis so you can bring the whole platform up with one command.
+
+> The marketing site (`apps/landing`) is a Cloudflare Workers app and is **not** part of the self-host stack.
+
+## Prerequisites
+
+- **Docker 23+** with BuildKit (the Dockerfiles use `COPY --parents`). BuildKit is the default in modern Docker; if you're on an old engine, set `DOCKER_BUILDKIT=1`.
+- An **S3-compatible object store** (Cloudflare R2, AWS S3, or the bundled MinIO profile) — required for advertiser image uploads and favicons.
+- **Stripe** account (Connect enabled), **Google OAuth** credentials (publisher login), and an **AutoSend** API key (transactional email).
+
+## Quick start
+
+```bash
+cp .env.example .env
+# fill in the secrets — BETTER_AUTH_SECRET, Google OAuth, Stripe, AutoSend, S3.
+# Postgres and Redis are wired by compose, so you can ignore the DB/Redis vars.
+docker compose up -d --build
+```
+
+- Dashboard → http://localhost:8080
+- API → http://localhost:3001 (OpenAPI docs at http://localhost:3001/v1/docs)
+
+The `migrate` service runs `prisma db push` once on startup to sync the schema, then the `api` service boots.
+
+## Configuration
+
+All runtime configuration is via environment variables in a single `.env` (copied from `.env.example`). Compose wires the bundled Postgres and Redis automatically — it overrides `DATABASE_URL`/`REDIS_REST_URL` regardless of what `.env` says — so for the bundled stack you only fill in secrets. Two important nuances:
+
+### The dashboard's config is baked at build time
+
+`apps/app` is a client-side SPA, so its `VITE_*` values (`VITE_API_URL`, `VITE_BASE_URL`, …) are **compiled into the JS bundle** when the image is built. Compose passes them as build args from your `.env`. If you change any `VITE_*` value, rebuild the image:
+
+```bash
+docker compose build app && docker compose up -d app
+```
+
+For a custom build outside compose:
+
+```bash
+docker build -f apps/app/Dockerfile -t openads-app \
+  --build-arg VITE_API_URL=https://api.example.com \
+  --build-arg VITE_BASE_URL=https://app.example.com .
+```
+
+`VITE_OPENPANEL_CLIENT_ID` and `VITE_COSSISTANT_PUBLIC_KEY` are optional third-party integrations (product analytics / support widget). Leave them empty for a self-hosted instance — both features no-op when unset (OpenPanel isn't mounted; the Cossistant support widget stays dormant).
+
+### Redis is reached over the Upstash REST protocol
+
+The app talks to Redis through the Upstash REST client. Compose runs `hiett/serverless-redis-http` in front of a plain Redis container so you don't need an Upstash cloud account — `REDIS_REST_URL=http://serverless-redis-http:80` and `REDIS_REST_TOKEN` must equal the proxy's `SRH_TOKEN`. To use Upstash cloud instead, just point those two vars at your Upstash database and remove the `redis` / `serverless-redis-http` services.
+
+## Object storage
+
+Set the `S3_*` vars to any S3-compatible store. For **Cloudflare R2**:
+
+```
+S3_REGION=auto
+S3_ENDPOINT=https://<account>.r2.cloudflarestorage.com
+S3_PUBLIC_URL=https://<your-public-bucket-domain>
+S3_ACCESS_KEY_ID=<r2 token id>
+S3_SECRET_ACCESS_KEY=<r2 token secret>
+S3_BUCKET=openads
+```
+
+### Bundled MinIO (optional)
+
+```bash
+docker compose --profile storage up -d --build
+```
+
+This starts MinIO + creates the bucket with public-download access. **Presigned-upload caveat:** the browser uploads directly to `S3_ENDPOINT`, so that URL must be reachable by *both* the browser and the API with the *same* host (otherwise the signature host won't match). On a single host this means putting MinIO behind your public domain/reverse proxy and setting `S3_ENDPOINT` + `S3_PUBLIC_URL` to that one URL. Pure-`localhost` setups work for the API but the browser-side upload can fail the signature check — MinIO is best used when deployed behind a real domain. For zero-fuss storage, R2 is the simplest option.
+
+## Migrations
+
+The project currently syncs schema with `prisma db push` (no migrations folder yet). The `migrate` service does this on every `up`. Once migrations are adopted, change that service's command to `bunx prisma migrate deploy`.
+
+## Production notes
+
+- Put a TLS-terminating reverse proxy (Caddy, nginx, Traefik, Cloudflare Tunnel) in front of `app` (:80) and `api` (:3001). Set `APP_URL`/`API_URL`/`BETTER_AUTH_URL` and the `VITE_*` build args to your https domains.
+- Register the Stripe **Connect** webhook at `https://<api-domain>/webhooks/stripe` and put the signing secret in `STRIPE_CONNECT_WEBHOOK_SECRET`.
+- Set the Google OAuth redirect URI to `https://<api-domain>/api/auth/callback/google`.
+- The images run the full Bun workspace (including the Prisma CLI), so the same `api` image is reused for the `migrate` step.
+
+## Pointing the SDK at your instance
+
+Publisher sites integrating via `@openads/sdk` / `@openads/react` pass your API URL explicitly:
+
+```ts
+createOpenAdsClient({ workspaceSlug: "your-slug", apiUrl: "https://api.example.com" })
+```
+
+## Building images individually
+
+```bash
+# from the repo root (build context must be the root)
+docker build -f apps/api/Dockerfile -t openads-api .
+docker build -f apps/app/Dockerfile -t openads-app --build-arg VITE_API_URL=... --build-arg VITE_BASE_URL=... .
+```


### PR DESCRIPTION
Phase 1.1 of the OpenAds → Dirstarter migration: make the API and dashboard self-hostable as Docker images (for our own deploy and for open-source users).

## What's included
- **`apps/api/Dockerfile`** — multi-stage Bun image for the Hono API. Frozen install, Prisma client generated at build, runs `bun run src/index.ts`. Healthcheck on `/`.
- **`apps/app/Dockerfile`** — builds the Vite SPA, serves static `dist/` via nginx. `VITE_*` config passed as build args (baked into the bundle).
- **`apps/app/docker/nginx.conf`** — SPA fallback + immutable asset caching.
- **`docker-compose.yml`** — full self-host stack: Postgres + Redis + `serverless-redis-http` (Upstash-compat shim) + one-shot `migrate` + API + app, plus an opt-in `storage` profile (MinIO).
- **`.env.example`** — single, complete env template (now includes the previously-missing required `S3_*` and `VITE_*` vars).
- **`.dockerignore`**, **`docs/self-hosting.md`** — self-host guide for OSS users.
- Dashboard analytics integrations (OpenPanel, Cossistant) made **optional** so a self-hosted build needs no third-party keys.
- **`bun.lock`** refreshed to match manifests (frozen-lockfile installs were failing on stale `@better-auth/*` pins).

## Verified
Built both images with `--frozen-lockfile` and ran the **full stack end-to-end** (`docker compose up`): migrate synced the schema, API serves and queries Postgres, the Redis-backed tracking endpoint responds, OpenAPI is served, and the dashboard SPA serves with working fallback.

## Security hardening (from automated review)
- Postgres has **no host port** — reachable only on the compose network.
- MinIO ports bound to **loopback** (`127.0.0.1`).
- Public-read on the MinIO bucket is intentional (holds ad creative rendered on third-party sites; uploads stay presigned). Documented + scoped to public ad assets.

## Notes
- Compose owns infra wiring (DB/Redis), so `.env` is secrets-only for the bundled stack.
- `.env.example` defaults target the Docker stack (`:8080`/`:3001`); local `bun run dev` uses `:5183` (noted inline).
- Migrations not yet adopted — `migrate` runs `prisma db push`; switch to `migrate deploy` in a later phase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)