### PR TITLE
fix: use constructEventAsync for stripe webhook verification

### DIFF
--- a/apps/api/src/routes/webhooks/stripe.ts
+++ b/apps/api/src/routes/webhooks/stripe.ts
@@ -13,8 +13,12 @@ import { stripe } from "../../services/stripe"
 
 export const stripeWebhookRoute = new Hono()
 
+// Must be the async variant: under the Bun runtime the Stripe SDK uses the
+// SubtleCrypto provider, whose HMAC is async-only — the synchronous
+// `constructEvent` throws "cannot be used in a synchronous context", which
+// would 400 every real webhook and break subscription sync.
 const constructStripeEvent = (body: string, signature: string) => {
-  return stripe.webhooks.constructEvent(body, signature, env.STRIPE_CONNECT_WEBHOOK_SECRET)
+  return stripe.webhooks.constructEventAsync(body, signature, env.STRIPE_CONNECT_WEBHOOK_SECRET)
 }
 
 stripeWebhookRoute.post("/", async c => {
@@ -28,7 +32,7 @@ stripeWebhookRoute.post("/", async c => {
   let event: Stripe.Event
 
   try {
-    event = constructStripeEvent(body, signature)
+    event = await constructStripeEvent(body, signature)
   } catch (err) {
     return c.text(`Invalid signature: ${err}`, 400)
   }


### PR DESCRIPTION
## Bug
The Stripe webhook handler used the **synchronous** `stripe.webhooks.constructEvent(...)`. Under the **Bun runtime** the Stripe SDK selects the `SubtleCrypto` provider, whose HMAC is **async-only**, so the sync call throws:

> `SubtleCryptoProvider cannot be used in a synchronous context. Use await constructEventAsync(...) instead of constructEvent(...)`

**Caught in production verification:** a correctly-signed test event POSTed to `https://api.openads.co/webhooks/stripe` returned `400 Invalid signature`. Every real Stripe webhook (connected-account `customer.subscription.*`, `account.updated`, …) would fail signature verification → subscriptions never sync → ads never serve (serving is gated on `Subscription.status ∈ Active/Trialing`).

## Fix
Switch to `constructEventAsync` and `await` it. One-line change, robust across Node/Bun/Workers runtimes.

## Verified
- Type-check passes (`@openads/api`).
- Pre-fix: signed event → `400 Invalid signature` (SubtleCrypto sync error).
- Post-deploy re-verification to follow (expect `200 OK`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)