### PR TITLE
fix(storage): use presigned PUT for advertiser uploads (R2 has no POST)

### DIFF
--- a/apps/app/src/components/ads/image-upload.tsx
+++ b/apps/app/src/components/ads/image-upload.tsx
@@ -49,17 +49,12 @@ export const ImageUpload = ({
         contentLength: file.size,
       })
 
-      // Presigned POST: every field from the signature must be in the form,
-      // and the file must come last (S3 requirement).
-      const form = new FormData()
-      for (const [name, value] of Object.entries(presigned.fields)) {
-        form.append(name, value)
-      }
-      form.append("file", file)
-
+      // Presigned PUT: send the file as the raw body with the signed headers.
+      // The browser sets Content-Length from the body, which the URL also signs.
       const uploadResponse = await fetch(presigned.uploadUrl, {
-        method: "POST",
-        body: form,
+        method: "PUT",
+        headers: presigned.headers,
+        body: file,
       })
 
       if (!uploadResponse.ok) {

--- a/packages/orpc/src/routers/storage.ts
+++ b/packages/orpc/src/routers/storage.ts
@@ -119,27 +119,20 @@ export const storageRouter = {
 
           const objectKey = `workspaces/${workspaceId}/uploads/${sessionId}/${generateObjectKey(fileName)}`
 
-          // Presigned POST (not PUT) so the size cap is enforced server-side
-          // at S3 via `content-length-range`.
-          const presigned = await s3.createSignedPost({
+          // Presigned PUT — R2 doesn't implement presigned POST (returns 501).
+          // The signed content-length pins the exact byte count, so the 2 MB cap
+          // is enforced by the storage backend, not just the check above.
+          const uploadUrl = await s3.getSignedUploadUrl({
             key: objectKey,
+            contentType,
+            contentLength,
             expiresInSeconds: ADVERTISER_UPLOAD_TTL_SECONDS,
-            contentLengthRange: { max: MAX_ADVERTISER_UPLOAD_BYTES },
-            // S3 requires the form to echo every signed field with the exact
-            // value, so these are returned to the client alongside `conditions`.
-            fields: {
-              "Content-Type": contentType,
-              "Cache-Control": "public, max-age=31536000, immutable",
-            },
-            conditions: [
-              ["eq", "$Content-Type", contentType],
-              ["eq", "$Cache-Control", "public, max-age=31536000, immutable"],
-            ],
           })
 
           return {
-            uploadUrl: presigned.url,
-            fields: presigned.fields,
+            uploadUrl,
+            // The client must send these exact headers on the PUT — they're signed.
+            headers: { "Content-Type": contentType },
             publicUrl: s3.getPublicUrl({ key: objectKey }),
             key: objectKey,
           }

--- a/packages/s3/src/client.ts
+++ b/packages/s3/src/client.ts
@@ -149,11 +149,19 @@ export function createS3BucketClient(config: S3BucketClientConfig) {
       Key: key,
       CacheControl: options.cacheControl,
       ContentType: options.contentType,
+      ContentLength: options.contentLength,
       Metadata: options.metadata,
       ACL: options.acl,
     })
 
-    return getSignedUrl(client, command, { expiresIn })
+    // Sign content-length so the backend rejects a body that doesn't match the
+    // declared size; without it in the signed set a client could PUT a larger file.
+    const signableHeaders =
+      options.contentLength != null
+        ? new Set(["host", "content-type", "content-length"])
+        : undefined
+
+    return getSignedUrl(client, command, { expiresIn, signableHeaders })
   }
 
   async function getSignedDownloadUrl(options: SignedDownloadUrlOptions) {

--- a/packages/s3/src/types.ts
+++ b/packages/s3/src/types.ts
@@ -46,6 +46,12 @@ export interface SignedUploadUrlOptions extends SignedUrlOptions {
   contentType?: string
   metadata?: PutObjectCommandInput["Metadata"]
   acl?: PutObjectCommandInput["ACL"]
+  /**
+   * When set, the byte length is signed into the URL so the storage backend
+   * rejects any upload whose body doesn't match exactly — a server-enforced
+   * size cap (R2 doesn't support the presigned-POST `content-length-range`).
+   */
+  contentLength?: number
 }
 
 export interface SignedDownloadUrlOptions extends SignedUrlOptions {


### PR DESCRIPTION
## Problem
Uploading a logo/image in the advertiser creative form failed with a browser **"Failed to fetch"**.

Diagnosis from production:
- The API's `createAdvertiserUpload` returned **200** — the presign succeeded.
- The failure was the browser's direct upload to R2. R2 returns **`501 NotImplemented` — "Presigned post requests are not yet implemented"** for S3 presigned **POST**, and that error response carries no CORS headers, so the browser surfaces it as "Failed to fetch".

The storage router used presigned **POST** (`createSignedPost`) to enforce the size cap via `content-length-range`. R2 doesn't implement presigned POST at all.

## Fix
Switch the advertiser upload to a presigned **PUT** (which R2 supports), preserving the hard size cap:

- **`@openads/s3`**: `getSignedUploadUrl` gains an optional `contentLength` that is signed into the URL (`signableHeaders` includes `content-length`). The backend then rejects any body whose length doesn't match the declared size. Verified directly against R2: exact length → **200**, oversized body → **403**.
- **storage router**: `createAdvertiserUpload` now returns `{ uploadUrl, headers, publicUrl, key }` for a PUT (the per-session Stripe-checkout gate, rate limit, type/size validation are unchanged).
- **`image-upload.tsx`**: PUTs the file as the raw body with the signed `Content-Type` header instead of a multipart form POST.

The publisher-side `uploadUserImage` path is unaffected (it uploads server-side via `PutObject`, which R2 supports).

## Also required (done out-of-band, not in this diff)
A CORS policy on the `openads` R2 bucket allowing `https://app.openads.co` (+ `http://localhost:5183`) — the object-scoped S3 token can't manage CORS, so it was set via the Cloudflare API. Recorded in the infra skill.

## Verification
- Reproduced the 501 against R2 with presigned POST; confirmed presigned PUT → 200 and the signed-content-length size enforcement (oversize → 403).
- Lint, format, typecheck pass.

Once merged + autodeployed, the logo upload in the creative form works end-to-end.