### PR TITLE
fix(storage): shorten upload keys and truncate asset URL in the ad form

### DIFF
--- a/apps/app/src/components/ads/image-upload.tsx
+++ b/apps/app/src/components/ads/image-upload.tsx
@@ -81,10 +81,16 @@ export const ImageUpload = ({
       />
 
       {value ? (
-        <div className="flex flex-1 items-center gap-3">
-          <img src={value} alt="" className="size-12 rounded border object-cover" />
-          <span className="flex-1 truncate text-muted-foreground text-xs">{value}</span>
-          <Button type="button" variant="ghost" prefix={<TrashIcon />} onClick={handleClear}>
+        <div className="flex min-w-0 flex-1 items-center gap-3">
+          <img src={value} alt="" className="size-12 shrink-0 rounded border object-cover" />
+          <span className="min-w-0 flex-1 truncate text-muted-foreground text-xs">{value}</span>
+          <Button
+            type="button"
+            variant="ghost"
+            className="shrink-0"
+            prefix={<TrashIcon />}
+            onClick={handleClear}
+          >
             Remove
           </Button>
         </div>

--- a/packages/orpc/src/routers/storage.ts
+++ b/packages/orpc/src/routers/storage.ts
@@ -14,9 +14,11 @@ const uploadImageInput = z.object({
 
 function generateObjectKey(fileName: string) {
   const extension = fileName.split(".").pop()?.toLowerCase() || "png"
-  const baseName = slugify(fileName.replace(/\.[^.]+$/, "")) || "file"
+  const baseName = slugify(fileName.replace(/\.[^.]+$/, "")).slice(0, 40) || "file"
 
-  return `${baseName}-${Date.now()}-${randomUUID()}.${extension}`
+  // A short random suffix is plenty for uniqueness within the workspace prefix —
+  // a timestamp + full UUID just made the public asset URLs needlessly long.
+  return `${baseName}-${randomUUID().slice(0, 8)}.${extension}`
 }
 
 // SVG is intentionally excluded — it can execute JS when rendered via <img>
@@ -117,7 +119,10 @@ export const storageRouter = {
             })
           }
 
-          const objectKey = `workspaces/${workspaceId}/uploads/${sessionId}/${generateObjectKey(fileName)}`
+          // Scoped to the workspace; the random key guarantees uniqueness. We don't
+          // fold the (long) Stripe session id into the path — uploads only happen
+          // after a completed checkout, so there are no orphans to group by session.
+          const objectKey = `workspaces/${workspaceId}/uploads/${generateObjectKey(fileName)}`
 
           // Presigned PUT — R2 doesn't implement presigned POST (returns 501).
           // The signed content-length pins the exact byte count, so the 2 MB cap


### PR DESCRIPTION
Two issues from the "Set up your ad" form (reported during smoke testing):

### 1. Long URL broke the page layout
The uploaded asset URL is shown in a flex row with `truncate`, but a flex item can't shrink below its content width without `min-w-0` — so it never truncated and pushed the whole form (and submit button) past the viewport.

**Fix:** add `min-w-0` to the URL span and its row, `shrink-0` to the thumbnail and Remove button. The URL now truncates with an ellipsis inside its column.

### 2. The upload URL was needlessly long
The object key was:
```
workspaces/{wsId}/uploads/{full-stripe-session-id}/{name}-{timestamp}-{full-uuid}.ext
```
Three redundant length sources: the full Stripe session id (~64 chars), a `Date.now()` timestamp, and a full UUID.

**Fix:**
- Drop the session-id folder. Uploads only happen *after* a completed checkout (the handler verifies `session.status === "complete"`), so there are no abandoned-checkout orphans to group by session, and the random key already guarantees uniqueness. Auth + rate-limit still use the session id; it's just not in the object path.
- Replace `timestamp + full UUID` with an 8-char random suffix; cap the slugified base name at 40 chars.

Result:
```
.../uploads/openads-avatar-0df448ad.png
```
instead of
```
.../uploads/cs_test_…64chars…/openads-avatar-1781032012775-0df448ad-…-af4c173e8f2a.png
```

Only affects new uploads; existing asset URLs are unchanged. Lint, format, typecheck pass.