### PR TITLE
fix(ads): resolve checkout email from customer_details; stop form overflow

### DIFF
--- a/apps/app/src/components/ads/image-upload.tsx
+++ b/apps/app/src/components/ads/image-upload.tsx
@@ -83,7 +83,11 @@ export const ImageUpload = ({
       {value ? (
         <div className="flex min-w-0 flex-1 items-center gap-3">
           <img src={value} alt="" className="size-12 shrink-0 rounded border object-cover" />
-          <span className="min-w-0 flex-1 truncate text-muted-foreground text-xs">{value}</span>
+          {/* Show the file name, not the full CDN URL — a long URL is ugly and,
+              as an unbreakable string, forces the form wider than its container. */}
+          <span className="min-w-0 flex-1 truncate text-muted-foreground text-xs" title={value}>
+            {value.split("/").pop() || value}
+          </span>
           <Button
             type="button"
             variant="ghost"

--- a/apps/app/src/routes/advertise/success.tsx
+++ b/apps/app/src/routes/advertise/success.tsx
@@ -54,7 +54,7 @@ function AdvertiseSuccess() {
   }
 
   return (
-    <div className="mx-auto max-w-xl px-6 py-10">
+    <div className="mx-auto w-full max-w-xl px-6 py-10">
       <div className="mb-8 grid gap-3 text-center">
         <h1 className="font-semibold text-2xl">Set up your ad</h1>
         <p className="text-muted-foreground text-sm">

--- a/packages/orpc/src/routers/ad.ts
+++ b/packages/orpc/src/routers/ad.ts
@@ -256,7 +256,9 @@ const createFromCheckout = publicProcedure
       )
       const metadata = stripeSubscription.metadata ?? session.metadata
       const tierPriceId = metadata?.tierPriceId
-      const customerEmail = session.customer_email
+      // Stripe collects the email on its hosted page (we no longer pre-fill
+      // `customer_email`), so it lands in `customer_details.email`.
+      const customerEmail = session.customer_details?.email ?? session.customer_email
 
       if (!workspaceId || !tierPriceId || !customerEmail) {
         throw new ORPCError("BAD_REQUEST", { message: "Missing checkout metadata." })


### PR DESCRIPTION
Two issues on the advertiser "Set up your ad" form, found in testing.

## 1. "Missing checkout metadata" on submit
PR #13 (drop the email gate) stopped pre-filling `customer_email` on the checkout session — Stripe now collects the email on its own hosted page. But the submit handler (`ad.createFromCheckout`) read `session.customer_email`, which is now `null`, so it threw "Missing checkout metadata."

**Fix:** read the collected address from `session.customer_details.email` (with a fallback to `customer_email`). The page-load path was unaffected (it only reads `session.metadata.tierPriceId`).

## 2. Form overflowed to full-page width
The success container is a flex item of the `flex flex-col` `#app` shell. Without `w-full` it sizes to its content, and the asset URL — an unbreakable ~95-char string wider than `max-w-xl` — became the width driver, overriding the cap. `min-w-0`/`truncate` (added in #15) couldn't help because nothing in the chain had a definite width to truncate against. Same root cause as the earlier embed width bug.

**Fix:**
- Pin the success container with `w-full` (so it's exactly `max-w-xl`, content can't stretch it).
- Show just the **file name** in the upload row instead of the full CDN URL (full URL on `title` hover). A short, bounded string can't force the overflow, and it reads better.

Verified with a faithful headless repro of the `#app → max-w-xl → grid form → upload row` structure: before, the container stretched to ~740px with the URL untruncated; after, it stays centered at `max-w-xl` with the filename shown and no overflow.

Lint, format, typecheck pass.