### PR TITLE
Redesign ad review & advertiser pages, add workspace dashboard

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -39,6 +39,7 @@
     "react-day-picker": "^9.14.0",
     "react-dom": "^19.2.6",
     "react-hook-form": "^7.75.0",
+    "recharts": "^3.8.1",
     "sonner": "^2.0.7",
     "stripe": "^22.2.0",
     "zod": "^4.4.3",

--- a/apps/app/src/components/ads/ad-stats.tsx
+++ b/apps/app/src/components/ads/ad-stats.tsx
@@ -1,85 +1,83 @@
 import { formatNumber } from "@dirstack/utils"
+import { cx } from "@openads/ui/cva"
 import { Skeleton } from "@openads/ui/skeleton"
-import { Stack } from "@openads/ui/stack"
 import { useQuery } from "@tanstack/react-query"
+import type { ComponentProps } from "react"
 import { QueryCell } from "~/components/query-cell"
+import { PerformanceChart } from "~/components/stats/performance-chart"
 import { Card } from "~/components/ui/card"
-import { H4 } from "~/components/ui/heading"
-import { orpc } from "~/lib/orpc"
+import { H5 } from "~/components/ui/heading"
+import { orpc, type RouterOutputs } from "~/lib/orpc"
 
-type AdStatsProps = {
+type Stats = RouterOutputs["ad"]["getStats"]
+
+type AdStatsProps = ComponentProps<typeof Card> & {
   workspaceId: string
   adId: string
 }
 
-export const AdStats = ({ workspaceId, adId }: AdStatsProps) => {
+export const AdStats = ({ workspaceId, adId, ...props }: AdStatsProps) => {
   const statsQuery = useQuery(
     orpc.ad.getStats.queryOptions({ input: { workspaceId, adId, days: 30 } }),
   )
 
   return (
-    <Card>
-      <Card.Section>
-        <H4>Stats — last 30 days</H4>
+    <Card {...props}>
+      <Card.Section className="gap-4">
+        <div className="flex flex-wrap items-baseline justify-between gap-2">
+          <H5>Performance</H5>
+          <p className="text-muted-foreground text-xs">Last 30 days</p>
+        </div>
 
         <QueryCell
           query={statsQuery}
-          pending={() => <Skeleton className="mt-4 h-32" />}
-          error={() => <p className="mt-4 text-muted-foreground text-sm">Could not load stats.</p>}
-          success={({ data }) => (
-            <Stack direction="column" size="md" className="mt-4 items-stretch">
-              <div className="grid grid-cols-2 gap-4">
-                <Tile
-                  label="Impressions"
-                  value={formatNumber(data.totals.impressions, "standard")}
-                />
-                <Tile label="Clicks" value={formatNumber(data.totals.clicks, "standard")} />
-                <Tile
-                  label="CTR"
-                  value={
-                    data.totals.impressions > 0
-                      ? `${((data.totals.clicks / data.totals.impressions) * 100).toFixed(2)}%`
-                      : "—"
-                  }
-                />
-                <Tile label="Days reporting" value={String(data.rows.length)} />
-              </div>
-
-              {data.rows.length > 0 && (
-                <table className="w-full text-sm">
-                  <thead className="border-b text-muted-foreground text-xs uppercase">
-                    <tr>
-                      <th className="py-2 text-left">Date</th>
-                      <th className="py-2 text-right">Impressions</th>
-                      <th className="py-2 text-right">Clicks</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {data.rows.map(row => (
-                      <tr key={row.date.toISOString()} className="border-b last:border-b-0">
-                        <td className="py-2">{row.date.toISOString().slice(0, 10)}</td>
-                        <td className="py-2 text-right">
-                          {formatNumber(row.impressions, "standard")}
-                        </td>
-                        <td className="py-2 text-right">{formatNumber(row.clicks, "standard")}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              )}
-            </Stack>
-          )}
+          pending={() => <Skeleton className="h-64" />}
+          error={() => <p className="text-muted-foreground text-sm">Could not load stats.</p>}
+          success={({ data }) => <StatsBody stats={data} />}
         />
       </Card.Section>
     </Card>
   )
 }
 
-const Tile = ({ label, value }: { label: string; value: string }) => {
+const StatsBody = ({ stats }: { stats: Stats }) => {
+  const { rows, totals } = stats
+  const ctr = totals.impressions > 0 ? (totals.clicks / totals.impressions) * 100 : null
+
   return (
-    <div className="grid gap-1 rounded-md border px-3 py-2">
-      <span className="text-muted-foreground text-xs uppercase tracking-wide">{label}</span>
-      <span className="font-semibold text-xl">{value}</span>
+    <>
+      <div className="grid grid-cols-3 divide-x rounded-lg border">
+        <StatTile label="Impressions" value={formatNumber(totals.impressions, "standard")} />
+        <StatTile label="Clicks" value={formatNumber(totals.clicks, "standard")} />
+        <StatTile label="CTR" value={ctr === null ? "—" : `${ctr.toFixed(2)}%`} />
+      </div>
+
+      {rows.length > 0 ? (
+        <PerformanceChart rows={rows} />
+      ) : (
+        <div className="bg-dashed flex h-32 items-center justify-center rounded-lg border">
+          <p className="rounded-md bg-background px-3 py-1.5 text-muted-foreground text-sm">
+            No traffic recorded yet — stats appear once the ad starts serving.
+          </p>
+        </div>
+      )}
+    </>
+  )
+}
+
+const StatTile = ({
+  label,
+  value,
+  className,
+  ...props
+}: ComponentProps<"div"> & {
+  label: string
+  value: string
+}) => {
+  return (
+    <div className={cx("min-w-0 p-4", className)} {...props}>
+      <p className="text-muted-foreground text-xs uppercase tracking-wide">{label}</p>
+      <p className="mt-1 truncate font-display text-2xl font-semibold tabular-nums">{value}</p>
     </div>
   )
 }

--- a/apps/app/src/components/ads/serving-state.tsx
+++ b/apps/app/src/components/ads/serving-state.tsx
@@ -1,0 +1,73 @@
+import type { AdStatus, SubscriptionStatus } from "@openads/db/client"
+import { cx } from "@openads/ui/cva"
+import type { ComponentProps } from "react"
+
+type ServingInput = {
+  status: AdStatus
+  subscription: { status: SubscriptionStatus }
+}
+
+export type ServingState = ReturnType<typeof getServingState>
+
+const isPaid = (status: SubscriptionStatus) => status === "Active" || status === "Trialing"
+
+/**
+ * An ad serves only when the creative is approved AND the subscription is
+ * paid up — surface that two-flag rule as a single, glanceable state.
+ */
+export const getServingState = (ad: ServingInput) => {
+  const paid = isPaid(ad.subscription.status)
+
+  if (ad.status === "Approved" && paid) {
+    return {
+      dot: "bg-green-500",
+      ping: true,
+      label: "Serving",
+      detail: "Creative approved and subscription paid — this ad is in rotation.",
+    }
+  }
+  if (ad.status === "Approved") {
+    return {
+      dot: "bg-amber-500",
+      ping: false,
+      label: "Not serving",
+      detail: `Creative is approved, but the subscription is ${ad.subscription.status.toLowerCase()}.`,
+    }
+  }
+  if (ad.status === "Rejected") {
+    return {
+      dot: "bg-red-500",
+      ping: false,
+      label: "Not serving",
+      detail: "Creative was rejected — this ad is out of rotation.",
+    }
+  }
+  return {
+    dot: "bg-amber-400",
+    ping: false,
+    label: "Awaiting review",
+    detail: paid
+      ? "The subscription is paid. Approve the creative to start serving."
+      : `Subscription is ${ad.subscription.status.toLowerCase()} — the ad won't serve even once approved.`,
+  }
+}
+
+type ServingDotProps = ComponentProps<"span"> & {
+  state: ServingState
+}
+
+export const ServingDot = ({ state, className, ...props }: ServingDotProps) => {
+  return (
+    <span className={cx("relative flex size-2", className)} {...props}>
+      {state.ping && (
+        <span
+          className={cx(
+            "absolute inline-flex size-full animate-ping rounded-full opacity-60 [animation-duration:2s]",
+            state.dot,
+          )}
+        />
+      )}
+      <span className={cx("relative inline-flex size-full rounded-full", state.dot)} />
+    </span>
+  )
+}

--- a/apps/app/src/components/stats/performance-chart.tsx
+++ b/apps/app/src/components/stats/performance-chart.tsx
@@ -1,0 +1,84 @@
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+} from "@openads/ui/chart"
+import { cx } from "@openads/ui/cva"
+import type { ComponentProps } from "react"
+import { Area, AreaChart, CartesianGrid, XAxis } from "recharts"
+
+export type PerformanceRow = {
+  date: Date
+  impressions: number
+  clicks: number
+}
+
+const chartConfig = {
+  impressions: { label: "Impressions", color: "var(--color-chart-2)" },
+  clicks: { label: "Clicks", color: "var(--color-chart-1)" },
+} satisfies ChartConfig
+
+const tickFormatter = new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric" })
+
+type PerformanceChartProps = Omit<ComponentProps<typeof ChartContainer>, "config" | "children"> & {
+  rows: PerformanceRow[]
+}
+
+export const PerformanceChart = ({ rows, className, ...props }: PerformanceChartProps) => {
+  return (
+    <ChartContainer
+      config={chartConfig}
+      className={cx("aspect-auto h-56 w-full", className)}
+      {...props}
+    >
+      <AreaChart data={rows} margin={{ top: 4, right: 4, bottom: 0, left: 4 }}>
+        <defs>
+          <linearGradient id="fillImpressions" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="5%" stopColor="var(--color-impressions)" stopOpacity={0.3} />
+            <stop offset="95%" stopColor="var(--color-impressions)" stopOpacity={0.02} />
+          </linearGradient>
+        </defs>
+
+        <CartesianGrid vertical={false} strokeDasharray="3 3" className="stroke-border/75" />
+
+        <XAxis
+          dataKey="date"
+          tickLine={false}
+          axisLine={false}
+          tickMargin={8}
+          minTickGap={48}
+          tickFormatter={(date: Date) => tickFormatter.format(date)}
+        />
+
+        <ChartTooltip
+          cursor={{ className: "stroke-border" }}
+          content={({ content: _, ...props }) => (
+            <ChartTooltipContent
+              {...props}
+              labelFormatter={(_, payload) => {
+                const date = payload?.[0]?.payload?.date
+                return date instanceof Date ? tickFormatter.format(date) : ""
+              }}
+            />
+          )}
+        />
+
+        <Area
+          dataKey="impressions"
+          type="monotone"
+          stroke="var(--color-impressions)"
+          strokeWidth={1.5}
+          fill="url(#fillImpressions)"
+        />
+        <Area
+          dataKey="clicks"
+          type="monotone"
+          stroke="var(--color-clicks)"
+          strokeWidth={1.5}
+          fill="transparent"
+        />
+      </AreaChart>
+    </ChartContainer>
+  )
+}

--- a/apps/app/src/routes/$workspaceId/ads/$adId.tsx
+++ b/apps/app/src/routes/$workspaceId/ads/$adId.tsx
@@ -1,16 +1,18 @@
+import { formatDate, getInitials } from "@dirstack/utils"
+import { Avatar, AvatarFallback, AvatarImage } from "@openads/ui/avatar"
 import { Badge } from "@openads/ui/badge"
 import { Button } from "@openads/ui/button"
-import { Stack } from "@openads/ui/stack"
 import { Textarea } from "@openads/ui/textarea"
 import { useMutation, useQuery } from "@tanstack/react-query"
-import { createFileRoute, notFound } from "@tanstack/react-router"
-import { CheckIcon, MessageSquareIcon, XIcon } from "lucide-react"
-import { useState } from "react"
+import { createFileRoute, Link, notFound } from "@tanstack/react-router"
+import { ArrowUpRightIcon, CheckIcon, MessageSquareIcon, XIcon } from "lucide-react"
+import { type ReactNode, useState } from "react"
 import { toast } from "sonner"
 import { AdStats } from "~/components/ads/ad-stats"
+import { getServingState, ServingDot } from "~/components/ads/serving-state"
 import { Card } from "~/components/ui/card"
 import { Header, HeaderActions, HeaderTitle } from "~/components/ui/header"
-import { H4, H5 } from "~/components/ui/heading"
+import { H5, H6 } from "~/components/ui/heading"
 import { formatTierPrice } from "~/lib/currency"
 import { orpc, queryClient, type RouterOutputs } from "~/lib/orpc"
 
@@ -30,6 +32,34 @@ export const Route = createFileRoute("/$workspaceId/ads/$adId")({
 type Ad = NonNullable<RouterOutputs["ad"]["getById"]>
 type FieldList = RouterOutputs["field"]["getAll"]
 
+const statusVariant: Record<Ad["status"], "secondary" | "success" | "danger"> = {
+  Pending: "secondary",
+  Approved: "success",
+  Rejected: "danger",
+}
+
+const subscriptionVariant: Record<
+  Ad["subscription"]["status"],
+  "secondary" | "success" | "warning" | "danger"
+> = {
+  Trialing: "success",
+  Active: "success",
+  PastDue: "warning",
+  Canceled: "secondary",
+  Unpaid: "danger",
+  Incomplete: "warning",
+  IncompleteExpired: "secondary",
+  Paused: "secondary",
+}
+
+const faviconUrl = (websiteUrl: string) => {
+  try {
+    return `https://www.google.com/s2/favicons?sz=128&domain=${new URL(websiteUrl).hostname}`
+  } catch {
+    return undefined
+  }
+}
+
 function AdReviewPage() {
   const { workspaceId, adId } = Route.useParams()
   const { ad: initial, fields } = Route.useLoaderData()
@@ -38,11 +68,13 @@ function AdReviewPage() {
     orpc.ad.getById.queryOptions({ input: { workspaceId, adId }, initialData: initial }),
   )
   const ad = adQuery.data ?? initial
+  const serving = getServingState(ad)
 
   const [note, setNote] = useState("")
 
   const onDecided = (action: string) => async () => {
     toast.success(`Ad ${action}`)
+    setNote("")
     await queryClient.invalidateQueries({
       queryKey: orpc.ad.getById.key({ input: { workspaceId, adId } }),
     })
@@ -78,75 +110,177 @@ function AdReviewPage() {
     return true
   }
 
+  const { subscription } = ad
+  const { advertiser, tier, tierPrice } = subscription
+
   return (
     <>
       <Header>
-        <HeaderTitle>{ad.name}</HeaderTitle>
+        <div className="flex min-w-0 items-center gap-3">
+          <Avatar className="size-11 rounded-md border">
+            <AvatarImage src={faviconUrl(ad.websiteUrl)} className="p-1.5" />
+            <AvatarFallback className="rounded-none">{getInitials(ad.name)}</AvatarFallback>
+          </Avatar>
+
+          <div className="min-w-0">
+            <HeaderTitle className="truncate">{ad.name}</HeaderTitle>
+            <p className="truncate text-muted-foreground text-sm">
+              Submitted {formatDate(ad.createdAt, "medium", "en-US")} ·{" "}
+              {advertiser.email ?? advertiser.name} · {tier.name}
+            </p>
+          </div>
+        </div>
 
         <HeaderActions>
-          <Badge>{ad.status}</Badge>
+          <Badge variant={statusVariant[ad.status]} size="lg">
+            {ad.status}
+          </Badge>
+
+          <Button variant="secondary" suffix={<ArrowUpRightIcon />} asChild>
+            <a href={ad.websiteUrl} target="_blank" rel="noreferrer">
+              Visit site
+            </a>
+          </Button>
         </HeaderActions>
       </Header>
 
-      <div className="grid gap-6 lg:grid-cols-[2fr_1fr]">
-        <Stack direction="column" size="md" className="items-stretch">
-          <Card>
-            <Card.Section>
-              <H4>Creative</H4>
-              <Stack direction="column" size="sm" className="mt-4">
-                <Field label="Destination">
+      <div className="grid items-start gap-6 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+        <div className="flex flex-col gap-6">
+          <Card className="animate-slide-up-and-fade [animation-fill-mode:backwards]">
+            <Card.Section className="gap-4">
+              <H5>Creative</H5>
+
+              <dl className="divide-y divide-border/60">
+                <DetailRow label="Destination">
                   <a
                     href={ad.websiteUrl}
                     target="_blank"
                     rel="noreferrer"
-                    className="break-all text-blue-600 underline"
+                    className="group inline-flex max-w-full items-center gap-1 font-medium underline decoration-border underline-offset-4 hover:decoration-foreground"
                   >
-                    {ad.websiteUrl}
+                    <span className="truncate">{ad.websiteUrl}</span>
+                    <ArrowUpRightIcon className="shrink-0 text-muted-foreground" />
                   </a>
-                </Field>
-                <Field label="Weight">{ad.subscription.tier.weight}</Field>
-                <Field label="Tier">{ad.subscription.tier.name}</Field>
-                <Field label="Billing">{formatTierPrice(ad.subscription.tierPrice)}</Field>
-                <Field label="Advertiser">
-                  {ad.subscription.advertiser.email ?? ad.subscription.advertiser.name}
-                </Field>
-              </Stack>
+                </DetailRow>
 
-              {ad.meta.length > 0 && (
-                <>
-                  <H5 className="mt-6">Custom fields</H5>
-                  <Stack direction="column" size="sm" className="mt-2">
-                    {ad.meta.map(m => (
-                      <Field key={m.id} label={fieldLabel(m.fieldId, fields)}>
-                        {renderMetaValue(m, fields)}
-                      </Field>
+                <DetailRow label="Tier">
+                  <span className="flex flex-wrap items-center gap-2">
+                    {tier.name}
+                    <Badge variant="soft" className="tabular-nums">
+                      {tier.weight}× weight
+                    </Badge>
+                  </span>
+                </DetailRow>
+
+                <DetailRow label="Billing">
+                  <span className="flex flex-wrap items-center gap-2 tabular-nums">
+                    {formatTierPrice(tierPrice)}
+                    <Badge variant={subscriptionVariant[subscription.status]}>
+                      {subscription.status}
+                    </Badge>
+                    {subscription.currentPeriodEnd &&
+                      ["Active", "Trialing"].includes(subscription.status) && (
+                        <span className="text-muted-foreground">
+                          {subscription.cancelAtPeriodEnd ? "ends" : "renews"}{" "}
+                          {formatDate(subscription.currentPeriodEnd, "medium", "en-US")}
+                        </span>
+                      )}
+                  </span>
+                </DetailRow>
+
+                <DetailRow label="Advertiser">
+                  <Link
+                    to="/$workspaceId/advertisers/$advertiserId"
+                    params={{ workspaceId, advertiserId: advertiser.id }}
+                    className="font-medium underline decoration-border underline-offset-4 hover:decoration-foreground"
+                  >
+                    {advertiser.email ?? advertiser.name}
+                  </Link>
+                </DetailRow>
+              </dl>
+            </Card.Section>
+
+            <Card.Section className="gap-4">
+              <div className="flex items-center gap-2">
+                <H5>Custom fields</H5>
+                <Badge variant="secondary">{ad.meta.length}</Badge>
+              </div>
+
+              {fields.length === 0 && ad.meta.length === 0 ? (
+                <p className="text-muted-foreground text-sm">
+                  This workspace has no custom fields.
+                </p>
+              ) : (
+                <dl className="divide-y divide-border/60">
+                  {fields.map(field => (
+                    <DetailRow key={field.id} label={field.name}>
+                      <MetaValue
+                        meta={ad.meta.find(m => m.fieldId === field.id)}
+                        type={field.type}
+                        name={field.name}
+                      />
+                    </DetailRow>
+                  ))}
+
+                  {/* Values whose field has since been deleted */}
+                  {ad.meta
+                    .filter(m => !fields.some(f => f.id === m.fieldId))
+                    .map(m => (
+                      <DetailRow key={m.id} label="Removed field">
+                        <MetaValue meta={m} type="Text" name="Removed field" />
+                      </DetailRow>
                     ))}
-                  </Stack>
-                </>
+                </dl>
               )}
             </Card.Section>
           </Card>
 
-          <AdStats workspaceId={workspaceId} adId={adId} />
-        </Stack>
+          <AdStats
+            workspaceId={workspaceId}
+            adId={adId}
+            className="animate-slide-up-and-fade [animation-delay:75ms] [animation-fill-mode:backwards]"
+          />
+        </div>
 
-        <Card>
-          <Card.Section>
-            <H4>Review</H4>
-            <p className="mt-2 text-muted-foreground text-sm">
-              Approve to start serving. Reject to cancel the subscription. Request changes to keep
-              the subscription active and ask the advertiser to resubmit.
-            </p>
+        <Card className="animate-slide-up-and-fade lg:sticky lg:top-6 [animation-delay:150ms] [animation-fill-mode:backwards]">
+          <Card.Section className="gap-4">
+            <div className="flex items-center gap-2.5">
+              <ServingDot state={serving} />
+              <H5>{serving.label}</H5>
+            </div>
 
-            <Textarea
-              className="mt-4"
-              placeholder="Note (optional for approve, required for reject / changes)"
-              value={note}
-              onChange={e => setNote(e.target.value)}
-              maxLength={500}
-            />
+            <p className="-mt-2.5 text-muted-foreground text-sm">{serving.detail}</p>
 
-            <Stack direction="column" size="sm" className="mt-4">
+            <dl className="divide-y divide-border/60 text-sm">
+              <TimelineRow label="Submitted" date={ad.createdAt} />
+              {ad.approvedAt && <TimelineRow label="Approved" date={ad.approvedAt} />}
+              {ad.rejectedAt && <TimelineRow label="Rejected" date={ad.rejectedAt} />}
+            </dl>
+
+            {ad.rejectionNote && (
+              <div className="rounded-md bg-muted px-3 py-2.5">
+                <H6 className="text-muted-foreground">Last review note</H6>
+                <p className="mt-1 text-sm">{ad.rejectionNote}</p>
+              </div>
+            )}
+          </Card.Section>
+
+          <Card.Section className="gap-4">
+            <H5>Decision</H5>
+
+            <div>
+              <Textarea
+                placeholder="Note to the advertiser…"
+                value={note}
+                onChange={e => setNote(e.target.value)}
+                maxLength={500}
+              />
+              <p className="mt-1.5 text-muted-foreground text-xs">
+                Optional for approve, required otherwise. The note is emailed to the advertiser.
+              </p>
+            </div>
+
+            <div className="flex flex-col gap-2">
               <Button
                 prefix={<CheckIcon />}
                 onClick={() =>
@@ -154,33 +288,43 @@ function AdReviewPage() {
                 }
                 isPending={approve.isPending}
                 disabled={ad.status === "Approved"}
+                className="w-full"
               >
                 Approve
               </Button>
-              <Button
-                variant="secondary"
-                prefix={<MessageSquareIcon />}
-                onClick={() => {
-                  if (!requireNote()) return
-                  requestChanges.mutate({ workspaceId, adId, note })
-                }}
-                isPending={requestChanges.isPending}
-              >
-                Request changes
-              </Button>
-              <Button
-                variant="destructive"
-                prefix={<XIcon />}
-                onClick={() => {
-                  if (!requireNote()) return
-                  reject.mutate({ workspaceId, adId, note })
-                }}
-                isPending={reject.isPending}
-                disabled={ad.status === "Rejected"}
-              >
-                Reject
-              </Button>
-            </Stack>
+
+              <div className="grid grid-cols-2 gap-2">
+                <Button
+                  variant="secondary"
+                  prefix={<MessageSquareIcon />}
+                  onClick={() => {
+                    if (!requireNote()) return
+                    requestChanges.mutate({ workspaceId, adId, note })
+                  }}
+                  isPending={requestChanges.isPending}
+                >
+                  Changes
+                </Button>
+                <Button
+                  variant="secondary"
+                  prefix={<XIcon />}
+                  onClick={() => {
+                    if (!requireNote()) return
+                    reject.mutate({ workspaceId, adId, note })
+                  }}
+                  isPending={reject.isPending}
+                  disabled={ad.status === "Rejected"}
+                  className="text-destructive hover:text-destructive"
+                >
+                  Reject
+                </Button>
+              </div>
+
+              <p className="text-muted-foreground text-xs">
+                Rejecting cancels the subscription. Requesting changes keeps it active and asks the
+                advertiser to resubmit.
+              </p>
+            </div>
           </Card.Section>
         </Card>
       </div>
@@ -188,30 +332,71 @@ function AdReviewPage() {
   )
 }
 
-function Field({ label, children }: { label: string; children: React.ReactNode }) {
+const DetailRow = ({ label, children }: { label: string; children: ReactNode }) => {
   return (
-    <div className="grid gap-1">
-      <span className="text-muted-foreground text-xs uppercase tracking-wide">{label}</span>
-      <div className="text-sm">{children}</div>
+    <div className="grid grid-cols-[7.5rem_minmax(0,1fr)] items-start gap-x-4 py-2.5 text-sm first:pt-0 last:pb-0">
+      <dt className="py-px text-muted-foreground">{label}</dt>
+      <dd className="min-w-0">{children}</dd>
     </div>
   )
 }
 
-function fieldLabel(fieldId: string, fields: FieldList) {
-  return fields.find(f => f.id === fieldId)?.name ?? fieldId
+const TimelineRow = ({ label, date }: { label: string; date: Date }) => {
+  return (
+    <div className="flex items-baseline justify-between gap-4 py-2 first:pt-0 last:pb-0">
+      <dt className="text-muted-foreground">{label}</dt>
+      <dd className="tabular-nums">{formatDate(date, "medium", "en-US")}</dd>
+    </div>
+  )
 }
 
-function renderMetaValue(m: Ad["meta"][number], fields: FieldList) {
-  const field = fields.find(f => f.id === m.fieldId)
-  const value = m.value as unknown
+type MetaValueProps = {
+  meta: Ad["meta"][number] | undefined
+  type: FieldList[number]["type"]
+  name: string
+}
 
-  if (field?.type === "Image" && typeof value === "string" && value.length > 0) {
-    return <img src={value} alt={field.name} className="max-h-32 rounded border object-contain" />
+const MetaValue = ({ meta, type, name }: MetaValueProps) => {
+  const value = meta?.value as unknown
+
+  if (value === undefined || value === null || value === "") {
+    return <span className="text-muted-foreground">—</span>
   }
 
-  if (field?.type === "Switch") {
-    return value ? "Yes" : "No"
+  if (type === "Image" && typeof value === "string") {
+    return (
+      <a
+        href={value}
+        target="_blank"
+        rel="noreferrer"
+        className="inline-block rounded-lg border bg-dashed p-1.5 hover:border-ring"
+      >
+        <img src={value} alt={name} className="max-h-36 rounded-sm object-contain" />
+      </a>
+    )
   }
 
-  return String(value ?? "")
+  if (type === "Switch") {
+    return <Badge variant="soft">{value ? "Yes" : "No"}</Badge>
+  }
+
+  if (type === "Url" && typeof value === "string") {
+    return (
+      <a
+        href={value}
+        target="_blank"
+        rel="noreferrer"
+        className="inline-flex max-w-full items-center gap-1 underline decoration-border underline-offset-4 hover:decoration-foreground"
+      >
+        <span className="truncate">{value}</span>
+        <ArrowUpRightIcon className="shrink-0 text-muted-foreground" />
+      </a>
+    )
+  }
+
+  if (type === "Number") {
+    return <span className="tabular-nums">{String(value)}</span>
+  }
+
+  return <span className="whitespace-pre-line">{String(value)}</span>
 }

--- a/apps/app/src/routes/$workspaceId/ads/$adId.tsx
+++ b/apps/app/src/routes/$workspaceId/ads/$adId.tsx
@@ -1,4 +1,4 @@
-import { formatDate, getInitials } from "@dirstack/utils"
+import { formatDate, getInitials, isValidUrl } from "@dirstack/utils"
 import { Avatar, AvatarFallback, AvatarImage } from "@openads/ui/avatar"
 import { Badge } from "@openads/ui/badge"
 import { Button } from "@openads/ui/button"
@@ -136,11 +136,13 @@ function AdReviewPage() {
             {ad.status}
           </Badge>
 
-          <Button variant="secondary" suffix={<ArrowUpRightIcon />} asChild>
-            <a href={ad.websiteUrl} target="_blank" rel="noreferrer">
-              Visit site
-            </a>
-          </Button>
+          {isValidUrl(ad.websiteUrl) && (
+            <Button variant="secondary" suffix={<ArrowUpRightIcon />} asChild>
+              <a href={ad.websiteUrl} target="_blank" rel="noreferrer">
+                Visit site
+              </a>
+            </Button>
+          )}
         </HeaderActions>
       </Header>
 
@@ -152,15 +154,19 @@ function AdReviewPage() {
 
               <dl className="divide-y divide-border/60">
                 <DetailRow label="Destination">
-                  <a
-                    href={ad.websiteUrl}
-                    target="_blank"
-                    rel="noreferrer"
-                    className="group inline-flex max-w-full items-center gap-1 font-medium underline decoration-border underline-offset-4 hover:decoration-foreground"
-                  >
-                    <span className="truncate">{ad.websiteUrl}</span>
-                    <ArrowUpRightIcon className="shrink-0 text-muted-foreground" />
-                  </a>
+                  {isValidUrl(ad.websiteUrl) ? (
+                    <a
+                      href={ad.websiteUrl}
+                      target="_blank"
+                      rel="noreferrer"
+                      className="group inline-flex max-w-full items-center gap-1 font-medium underline decoration-border underline-offset-4 hover:decoration-foreground"
+                    >
+                      <span className="truncate">{ad.websiteUrl}</span>
+                      <ArrowUpRightIcon className="shrink-0 text-muted-foreground" />
+                    </a>
+                  ) : (
+                    <span className="block truncate">{ad.websiteUrl}</span>
+                  )}
                 </DetailRow>
 
                 <DetailRow label="Tier">
@@ -363,7 +369,7 @@ const MetaValue = ({ meta, type, name }: MetaValueProps) => {
     return <span className="text-muted-foreground">—</span>
   }
 
-  if (type === "Image" && typeof value === "string") {
+  if (type === "Image" && typeof value === "string" && isValidUrl(value)) {
     return (
       <a
         href={value}
@@ -380,7 +386,7 @@ const MetaValue = ({ meta, type, name }: MetaValueProps) => {
     return <Badge variant="soft">{value ? "Yes" : "No"}</Badge>
   }
 
-  if (type === "Url" && typeof value === "string") {
+  if (type === "Url" && typeof value === "string" && isValidUrl(value)) {
     return (
       <a
         href={value}

--- a/apps/app/src/routes/$workspaceId/advertisers/$advertiserId.tsx
+++ b/apps/app/src/routes/$workspaceId/advertisers/$advertiserId.tsx
@@ -1,4 +1,4 @@
-import { formatDate, formatNumber, getInitials } from "@dirstack/utils"
+import { formatDate, formatNumber, getInitials, isValidUrl } from "@dirstack/utils"
 import type { BillingInterval } from "@openads/db/client"
 import { Avatar, AvatarFallback, AvatarImage } from "@openads/ui/avatar"
 import { Badge } from "@openads/ui/badge"
@@ -140,7 +140,7 @@ function AdvertiserDetailPage() {
                   </Button>
                 )}
 
-                {advertiser.latestAd && (
+                {advertiser.latestAd && isValidUrl(advertiser.latestAd.websiteUrl) && (
                   <Button variant="secondary" suffix={<ArrowUpRightIcon />} asChild>
                     <a href={advertiser.latestAd.websiteUrl} target="_blank" rel="noreferrer">
                       Visit site

--- a/apps/app/src/routes/$workspaceId/advertisers/$advertiserId.tsx
+++ b/apps/app/src/routes/$workspaceId/advertisers/$advertiserId.tsx
@@ -1,34 +1,34 @@
-import { formatDate, formatDateRange, formatNumber, getInitials } from "@dirstack/utils"
-import { Avatar, AvatarFallback } from "@openads/ui/avatar"
+import { formatDate, formatNumber, getInitials } from "@dirstack/utils"
+import type { BillingInterval } from "@openads/db/client"
+import { Avatar, AvatarFallback, AvatarImage } from "@openads/ui/avatar"
 import { Badge } from "@openads/ui/badge"
 import { Button } from "@openads/ui/button"
 import { cx } from "@openads/ui/cva"
 import { Skeleton } from "@openads/ui/skeleton"
-import { Stack } from "@openads/ui/stack"
 import { useQuery } from "@tanstack/react-query"
 import { createFileRoute, Link } from "@tanstack/react-router"
-import { ExternalLinkIcon } from "lucide-react"
+import { ArrowUpRightIcon, MailIcon } from "lucide-react"
 import type { ComponentProps } from "react"
+import { getServingState, ServingDot } from "~/components/ads/serving-state"
 import { QueryCell } from "~/components/query-cell"
 import { Callout, CalloutText } from "~/components/ui/callout"
 import { Header, HeaderActions, HeaderTitle } from "~/components/ui/header"
 import { H5 } from "~/components/ui/heading"
-import { formatTierPrice } from "~/lib/currency"
+import { formatPrice, formatTierPrice } from "~/lib/currency"
 import { orpc, type RouterOutputs } from "~/lib/orpc"
+
+export const Route = createFileRoute("/$workspaceId/advertisers/$advertiserId")({
+  loader: async ({ context: { orpc, queryClient }, params: { workspaceId, advertiserId } }) => {
+    return await queryClient.fetchQuery(
+      orpc.advertiser.getById.queryOptions({ input: { workspaceId, advertiserId } }),
+    )
+  },
+
+  component: AdvertiserDetailPage,
+})
 
 type Advertiser = RouterOutputs["advertiser"]["getById"]
 type AdvertiserAd = Advertiser["ads"][number]
-
-const formatNullableDate = (date: Date | null) => {
-  if (!date) return "Not set"
-  return formatDate(date, "medium", "en-US")
-}
-
-const formatPeriod = (start: Date | null, end: Date | null) => {
-  if (!start && !end) return "No period"
-  if (!start || !end) return `${formatNullableDate(start)} - ${formatNullableDate(end)}`
-  return formatDateRange(start, end, "medium", "en-US")
-}
 
 const adStatusVariant: Record<AdvertiserAd["status"], "secondary" | "success" | "danger"> = {
   Pending: "secondary",
@@ -36,7 +36,7 @@ const adStatusVariant: Record<AdvertiserAd["status"], "secondary" | "success" | 
   Rejected: "danger",
 }
 
-const subscriptionStatusVariant: Record<
+const subscriptionVariant: Record<
   AdvertiserAd["subscription"]["status"],
   "secondary" | "success" | "warning" | "danger"
 > = {
@@ -50,75 +50,40 @@ const subscriptionStatusVariant: Record<
   Paused: "secondary",
 }
 
-type AdvertiserMetricProps = ComponentProps<"div"> & {
-  label: string
-  value: string | number
+const MONTHS_PER_INTERVAL: Record<BillingInterval, number> = {
+  Day: 1 / 30,
+  Week: 7 / 30,
+  Month: 1,
+  Year: 12,
 }
 
-const AdvertiserMetric = ({ label, value, className, ...props }: AdvertiserMetricProps) => {
-  return (
-    <div className={cx("min-w-0 p-4", className)} {...props}>
-      <p className="text-muted-foreground text-xs uppercase tracking-wide">{label}</p>
-      <p className="mt-1 truncate font-display text-2xl font-semibold">
-        {typeof value === "number" ? formatNumber(value, "standard") : value}
-      </p>
-    </div>
+/**
+ * Normalize the advertiser's paid subscriptions to a monthly figure — the
+ * number a publisher actually thinks in. Assumes one currency per workspace.
+ */
+const getMonthlyRevenue = (ads: AdvertiserAd[]) => {
+  const paid = ads.filter(
+    ad => ad.subscription.status === "Active" || ad.subscription.status === "Trialing",
   )
+  if (paid.length === 0) return null
+
+  const cents = paid.reduce((total, { subscription: { tierPrice } }) => {
+    const months = MONTHS_PER_INTERVAL[tierPrice.interval] * tierPrice.intervalCount
+    return total + tierPrice.amount / months
+  }, 0)
+
+  return formatPrice(Math.round(cents), paid[0]!.subscription.tierPrice.currency)
 }
 
-type AdvertiserAdRowProps = ComponentProps<"div"> & {
-  workspaceId: string
-  ad: AdvertiserAd
+const faviconUrl = (websiteUrl: string) => {
+  try {
+    return `https://www.google.com/s2/favicons?sz=128&domain=${new URL(websiteUrl).hostname}`
+  } catch {
+    return undefined
+  }
 }
 
-const AdvertiserAdRow = ({ workspaceId, ad, className, ...props }: AdvertiserAdRowProps) => {
-  return (
-    <div
-      className={cx(
-        "relative grid gap-3 px-4 py-4 hover:bg-muted/50 lg:grid-cols-[1fr_13rem_12rem_10rem] lg:items-center",
-        className,
-      )}
-      {...props}
-    >
-      <Link to="/$workspaceId/ads/$adId" params={{ workspaceId, adId: ad.id }} className="min-w-0">
-        <Stack size="sm">
-          <H5 className="truncate">{ad.name}</H5>
-          <Badge variant={adStatusVariant[ad.status]}>{ad.status}</Badge>
-          <Badge variant={subscriptionStatusVariant[ad.subscription.status]}>
-            {ad.subscription.status}
-          </Badge>
-        </Stack>
-        <p className="mt-1 truncate text-muted-foreground text-sm">{ad.websiteUrl}</p>
-        <span className="absolute inset-0" />
-      </Link>
-
-      <div className="min-w-0 text-sm">
-        <p className="truncate font-medium">{ad.subscription.tier.name}</p>
-        <p className="truncate text-muted-foreground">
-          {formatTierPrice(ad.subscription.tierPrice)}
-        </p>
-      </div>
-
-      <div className="text-sm">
-        <p className="text-muted-foreground">Current period</p>
-        <p>{formatPeriod(ad.subscription.currentPeriodStart, ad.subscription.currentPeriodEnd)}</p>
-      </div>
-
-      <div className="flex gap-4 text-sm lg:justify-end">
-        <div>
-          <p className="font-medium">{formatNumber(ad.stats.impressions, "standard")}</p>
-          <p className="text-muted-foreground">Impressions</p>
-        </div>
-        <div>
-          <p className="font-medium">{formatNumber(ad.stats.clicks, "standard")}</p>
-          <p className="text-muted-foreground">Clicks</p>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-const AdvertiserDetailPage = () => {
+function AdvertiserDetailPage() {
   const { workspaceId, advertiserId } = Route.useParams()
   const initial = Route.useLoaderData()
 
@@ -138,69 +103,194 @@ const AdvertiserDetailPage = () => {
           <CalloutText>Could not load advertiser.</CalloutText>
         </Callout>
       )}
-      success={({ data: advertiser }) => (
-        <>
-          <Header>
-            <div className="flex min-w-0 items-center gap-3">
-              <Avatar className="size-11">
-                <AvatarFallback>{getInitials(advertiser.name)}</AvatarFallback>
-              </Avatar>
+      success={({ data: advertiser }) => {
+        const { totals } = advertiser
+        const ctr = totals.impressions > 0 ? (totals.clicks / totals.impressions) * 100 : null
+        const monthlyRevenue = getMonthlyRevenue(advertiser.ads)
 
-              <div className="min-w-0">
-                <HeaderTitle>{advertiser.name}</HeaderTitle>
-                <p className="truncate text-muted-foreground text-sm">
-                  {advertiser.email ?? "No email"} · First seen{" "}
-                  {formatDate(advertiser.createdAt, "medium", "en-US")}
-                </p>
+        return (
+          <>
+            <Header>
+              <div className="flex min-w-0 items-center gap-3">
+                <Avatar className="size-11 rounded-md border">
+                  {advertiser.latestAd && (
+                    <AvatarImage
+                      src={faviconUrl(advertiser.latestAd.websiteUrl)}
+                      className="p-1.5"
+                    />
+                  )}
+                  <AvatarFallback className="rounded-none">
+                    {getInitials(advertiser.name)}
+                  </AvatarFallback>
+                </Avatar>
+
+                <div className="min-w-0">
+                  <HeaderTitle className="truncate">{advertiser.name}</HeaderTitle>
+                  <p className="truncate text-muted-foreground text-sm">
+                    {advertiser.email ?? "No email"} · Customer since{" "}
+                    {formatDate(advertiser.createdAt, "medium", "en-US")}
+                  </p>
+                </div>
+              </div>
+
+              <HeaderActions>
+                {advertiser.email && (
+                  <Button variant="secondary" prefix={<MailIcon />} asChild>
+                    <a href={`mailto:${advertiser.email}`}>Email</a>
+                  </Button>
+                )}
+
+                {advertiser.latestAd && (
+                  <Button variant="secondary" suffix={<ArrowUpRightIcon />} asChild>
+                    <a href={advertiser.latestAd.websiteUrl} target="_blank" rel="noreferrer">
+                      Visit site
+                    </a>
+                  </Button>
+                )}
+              </HeaderActions>
+            </Header>
+
+            <div className="grid animate-slide-up-and-fade grid-cols-2 divide-y rounded-lg border [animation-fill-mode:backwards] sm:grid-cols-4 sm:divide-y-0 sm:divide-x lg:grid-cols-5">
+              <Metric
+                label="Monthly revenue"
+                value={monthlyRevenue ?? "—"}
+                hint={
+                  monthlyRevenue
+                    ? `across ${totals.activeSubscriptions} paid`
+                    : "no paid subscriptions"
+                }
+              />
+              <Metric
+                label="Live ads"
+                value={totals.activeAds}
+                hint={`of ${totals.ads} submitted`}
+              />
+              <Metric label="30d impressions" value={totals.impressions} />
+              <Metric label="30d clicks" value={totals.clicks} />
+              <Metric
+                label="30d CTR"
+                value={ctr === null ? "—" : `${ctr.toFixed(2)}%`}
+                className="col-span-2 border-t sm:col-span-1 sm:border-t-0"
+              />
+            </div>
+
+            <div className="mt-2 flex animate-slide-up-and-fade flex-col gap-3 [animation-delay:75ms] [animation-fill-mode:backwards]">
+              <div className="flex items-center gap-2">
+                <H5>Ads</H5>
+                <Badge variant="secondary">{advertiser.ads.length}</Badge>
+              </div>
+
+              <div className="flex flex-col divide-y rounded-lg border">
+                {advertiser.ads.map(ad => (
+                  <AdvertiserAdRow key={ad.id} workspaceId={workspaceId} ad={ad} />
+                ))}
               </div>
             </div>
-
-            {advertiser.latestAd && (
-              <HeaderActions>
-                <Button variant="secondary" prefix={<ExternalLinkIcon />} asChild>
-                  <a href={advertiser.latestAd.websiteUrl} target="_blank" rel="noreferrer">
-                    Visit site
-                  </a>
-                </Button>
-              </HeaderActions>
-            )}
-          </Header>
-
-          <div className="grid divide-y rounded-lg border sm:grid-cols-2 sm:divide-x sm:divide-y-0 lg:grid-cols-5">
-            <AdvertiserMetric label="Ads" value={advertiser.totals.ads} />
-            <AdvertiserMetric label="Live ads" value={advertiser.totals.activeAds} />
-            <AdvertiserMetric
-              label="Active subscriptions"
-              value={advertiser.totals.activeSubscriptions}
-            />
-            <AdvertiserMetric label="30d impressions" value={advertiser.totals.impressions} />
-            <AdvertiserMetric label="30d clicks" value={advertiser.totals.clicks} />
-          </div>
-
-          <div className="mt-6">
-            <Stack className="mb-3" size="sm">
-              <H5>Ads</H5>
-              <Badge variant="secondary">{advertiser.ads.length}</Badge>
-            </Stack>
-
-            <div className="flex flex-col divide-y rounded-lg border">
-              {advertiser.ads.map(ad => (
-                <AdvertiserAdRow key={ad.id} workspaceId={workspaceId} ad={ad} />
-              ))}
-            </div>
-          </div>
-        </>
-      )}
+          </>
+        )
+      }}
     />
   )
 }
 
-export const Route = createFileRoute("/$workspaceId/advertisers/$advertiserId")({
-  loader: async ({ context: { orpc, queryClient }, params: { workspaceId, advertiserId } }) => {
-    return await queryClient.fetchQuery(
-      orpc.advertiser.getById.queryOptions({ input: { workspaceId, advertiserId } }),
-    )
-  },
+type MetricProps = ComponentProps<"div"> & {
+  label: string
+  value: string | number
+  hint?: string
+}
 
-  component: AdvertiserDetailPage,
-})
+const Metric = ({ label, value, hint, className, ...props }: MetricProps) => {
+  return (
+    <div className={cx("min-w-0 p-4", className)} {...props}>
+      <p className="text-muted-foreground text-xs uppercase tracking-wide">{label}</p>
+      <p className="mt-1 truncate font-display text-2xl font-semibold tabular-nums">
+        {typeof value === "number" ? formatNumber(value, "standard") : value}
+      </p>
+      {hint && <p className="truncate text-muted-foreground text-xs">{hint}</p>}
+    </div>
+  )
+}
+
+type AdvertiserAdRowProps = ComponentProps<"div"> & {
+  workspaceId: string
+  ad: AdvertiserAd
+}
+
+const AdvertiserAdRow = ({ workspaceId, ad, className, ...props }: AdvertiserAdRowProps) => {
+  const { subscription } = ad
+  const serving = getServingState(ad)
+  const paid = subscription.status === "Active" || subscription.status === "Trialing"
+
+  return (
+    <div
+      className={cx(
+        "relative grid gap-x-4 gap-y-2 px-4 py-3.5 hover:bg-muted/50 lg:grid-cols-[minmax(0,1fr)_11rem_10rem_11rem] lg:items-center",
+        className,
+      )}
+      {...props}
+    >
+      <Link
+        to="/$workspaceId/ads/$adId"
+        params={{ workspaceId, adId: ad.id }}
+        className="flex min-w-0 items-center gap-3"
+      >
+        <span className="relative shrink-0">
+          <Avatar className="size-9 rounded-md border">
+            <AvatarImage src={faviconUrl(ad.websiteUrl)} className="p-1" />
+            <AvatarFallback className="rounded-none text-xs">{getInitials(ad.name)}</AvatarFallback>
+          </Avatar>
+
+          {/* Presence-style serving indicator, anchored to the favicon */}
+          <span
+            className="-right-0.5 -bottom-0.5 absolute rounded-full bg-background p-0.5"
+            title={serving.detail}
+          >
+            <ServingDot state={serving} />
+          </span>
+        </span>
+
+        <span className="min-w-0">
+          <span className="flex items-center gap-2">
+            <H5 className="truncate">{ad.name}</H5>
+            <Badge variant={adStatusVariant[ad.status]}>{ad.status}</Badge>
+          </span>
+          <span className="block truncate text-muted-foreground text-sm">{ad.websiteUrl}</span>
+        </span>
+
+        <span className="absolute inset-0" />
+      </Link>
+
+      <div className="min-w-0 text-sm">
+        <p className="truncate font-medium">{subscription.tier.name}</p>
+        <p className="truncate text-muted-foreground tabular-nums">
+          {formatTierPrice(subscription.tierPrice)}
+        </p>
+      </div>
+
+      <div className="min-w-0 text-sm">
+        <p>
+          <Badge variant={subscriptionVariant[subscription.status]}>{subscription.status}</Badge>
+        </p>
+        {subscription.currentPeriodEnd && paid && (
+          <p className="mt-1 truncate text-muted-foreground tabular-nums">
+            {subscription.cancelAtPeriodEnd ? "Ends" : "Renews"}{" "}
+            {formatDate(subscription.currentPeriodEnd, "medium", "en-US")}
+          </p>
+        )}
+      </div>
+
+      <div className="flex gap-5 text-sm lg:justify-end lg:text-right">
+        <div>
+          <p className="font-medium tabular-nums">
+            {formatNumber(ad.stats.impressions, "standard")}
+          </p>
+          <p className="text-muted-foreground">Impressions</p>
+        </div>
+        <div>
+          <p className="font-medium tabular-nums">{formatNumber(ad.stats.clicks, "standard")}</p>
+          <p className="text-muted-foreground">Clicks</p>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/app/src/routes/$workspaceId/index.tsx
+++ b/apps/app/src/routes/$workspaceId/index.tsx
@@ -1,19 +1,62 @@
-import { createFileRoute, useNavigate } from "@tanstack/react-router"
+import { formatDate, formatNumber, getInitials } from "@dirstack/utils"
+import { Avatar, AvatarFallback, AvatarImage } from "@openads/ui/avatar"
+import { Badge } from "@openads/ui/badge"
+import { Button } from "@openads/ui/button"
+import { cx } from "@openads/ui/cva"
+import { Skeleton } from "@openads/ui/skeleton"
+import { useQuery } from "@tanstack/react-query"
+import { createFileRoute, Link, useNavigate } from "@tanstack/react-router"
+import { CheckIcon, CodeXmlIcon } from "lucide-react"
+import type { ComponentProps, ReactNode } from "react"
 import { z } from "zod"
+import { getServingState, ServingDot } from "~/components/ads/serving-state"
 import { WelcomeModal } from "~/components/modals/welcome-modal"
-import { H3 } from "~/components/ui/heading"
+import { QueryCell } from "~/components/query-cell"
+import { PerformanceChart } from "~/components/stats/performance-chart"
+import { Callout, CalloutText } from "~/components/ui/callout"
+import { Card } from "~/components/ui/card"
+import { Header, HeaderActions, HeaderTitle } from "~/components/ui/header"
+import { H5 } from "~/components/ui/heading"
+import { useWorkspace } from "~/contexts/workspace-context"
+import { formatPrice } from "~/lib/currency"
+import { orpc, type RouterOutputs } from "~/lib/orpc"
 
 export const Route = createFileRoute("/$workspaceId/")({
   validateSearch: z.object({
     onboarded: z.boolean().optional(),
   }),
 
+  loader: async ({ context: { orpc, queryClient }, params: { workspaceId } }) => {
+    await queryClient.prefetchQuery(orpc.dashboard.get.queryOptions({ input: { workspaceId } }))
+  },
+
   component: DashboardPage,
 })
 
+type Dashboard = RouterOutputs["dashboard"]["get"]
+type DashboardAd = Dashboard["recentAds"][number]
+
+const adStatusVariant: Record<DashboardAd["status"], "secondary" | "success" | "danger"> = {
+  Pending: "secondary",
+  Approved: "success",
+  Rejected: "danger",
+}
+
+const faviconUrl = (websiteUrl: string) => {
+  try {
+    return `https://www.google.com/s2/favicons?sz=128&domain=${new URL(websiteUrl).hostname}`
+  } catch {
+    return undefined
+  }
+}
+
 function DashboardPage() {
+  const workspace = useWorkspace()
   const navigate = useNavigate({ from: Route.fullPath })
   const { onboarded } = Route.useSearch()
+  const { workspaceId } = Route.useParams()
+
+  const dashboardQuery = useQuery(orpc.dashboard.get.queryOptions({ input: { workspaceId } }))
 
   return (
     <>
@@ -23,7 +66,255 @@ function DashboardPage() {
           if (!open) navigate({ search: {}, replace: true })
         }}
       />
-      <H3>Dashboard</H3>
+
+      <Header>
+        <div className="min-w-0">
+          <HeaderTitle>Dashboard</HeaderTitle>
+          <p className="truncate text-muted-foreground text-sm">
+            What's happening across {workspace.name}
+          </p>
+        </div>
+
+        <HeaderActions>
+          <Button variant="secondary" prefix={<CodeXmlIcon />} asChild>
+            <Link to="/$workspaceId/embed" params={{ workspaceId }}>
+              Embed widget
+            </Link>
+          </Button>
+        </HeaderActions>
+      </Header>
+
+      <QueryCell
+        query={dashboardQuery}
+        pending={() => (
+          <>
+            <Skeleton className="h-24" />
+            <Skeleton className="h-80" />
+          </>
+        )}
+        error={() => (
+          <Callout variant="danger">
+            <CalloutText>Could not load the dashboard.</CalloutText>
+          </Callout>
+        )}
+        success={({ data }) => <DashboardBody workspaceId={workspaceId} data={data} />}
+      />
     </>
+  )
+}
+
+const DashboardBody = ({ workspaceId, data }: { workspaceId: string; data: Dashboard }) => {
+  const { revenue, counts, totals, series, pendingAds, recentAds } = data
+  const ctr = totals.impressions > 0 ? (totals.clicks / totals.impressions) * 100 : null
+
+  return (
+    <>
+      <div className="grid animate-slide-up-and-fade grid-cols-2 divide-y rounded-lg border [animation-fill-mode:backwards] sm:grid-cols-3 sm:divide-y-0 sm:divide-x lg:grid-cols-5">
+        <Metric
+          label="Monthly revenue"
+          value={
+            revenue.paidSubscriptions > 0
+              ? formatPrice(revenue.monthlyCents, revenue.currency)
+              : "—"
+          }
+          hint={
+            revenue.paidSubscriptions > 0
+              ? `across ${revenue.paidSubscriptions} paid`
+              : "no paid subscriptions"
+          }
+        />
+        <Metric label="Serving ads" value={counts.servingAds} hint={`of ${counts.ads} total`} />
+        <Metric
+          label="Pending review"
+          value={pendingAds.length}
+          hint={pendingAds.length > 0 ? "needs your decision" : "all caught up"}
+        />
+        <Metric label="30d impressions" value={totals.impressions} />
+        <Metric label="30d CTR" value={ctr === null ? "—" : `${ctr.toFixed(2)}%`} />
+      </div>
+
+      <Card className="animate-slide-up-and-fade [animation-delay:75ms] [animation-fill-mode:backwards]">
+        <Card.Section className="gap-4">
+          <div className="flex flex-wrap items-baseline justify-between gap-2">
+            <H5>Performance</H5>
+            <p className="text-muted-foreground text-xs">
+              {formatNumber(totals.clicks, "standard")} clicks · Last 30 days
+            </p>
+          </div>
+
+          {series.length > 0 ? (
+            <PerformanceChart rows={series} />
+          ) : (
+            <div className="bg-dashed flex h-32 items-center justify-center rounded-lg border">
+              <p className="rounded-md bg-background px-3 py-1.5 text-muted-foreground text-sm">
+                No traffic recorded yet — stats appear once ads start serving.
+              </p>
+            </div>
+          )}
+        </Card.Section>
+      </Card>
+
+      <div className="grid animate-slide-up-and-fade items-start gap-6 [animation-delay:150ms] [animation-fill-mode:backwards] lg:grid-cols-2">
+        <ListCard
+          title="Review queue"
+          count={pendingAds.length}
+          action={
+            pendingAds.length > 0 && (
+              <Link
+                to="/$workspaceId/ads"
+                params={{ workspaceId }}
+                search={{ status: "Pending" }}
+                className="text-muted-foreground text-sm hover:text-foreground"
+              >
+                View all
+              </Link>
+            )
+          }
+        >
+          {pendingAds.length === 0 ? (
+            <EmptyNote icon={<CheckIcon className="text-green-600 dark:text-green-400" />}>
+              All clear — nothing waiting for review.
+            </EmptyNote>
+          ) : (
+            <div className="flex flex-col divide-y">
+              {pendingAds.slice(0, 5).map(ad => (
+                <DashboardAdRow key={ad.id} workspaceId={workspaceId} ad={ad}>
+                  Submitted {formatDate(ad.createdAt, "medium", "en-US")} ·{" "}
+                  {ad.advertiser.email ?? ad.advertiser.name}
+                </DashboardAdRow>
+              ))}
+            </div>
+          )}
+        </ListCard>
+
+        <ListCard
+          title="Latest ads"
+          count={counts.ads}
+          action={
+            counts.ads > 0 && (
+              <Link
+                to="/$workspaceId/ads"
+                params={{ workspaceId }}
+                className="text-muted-foreground text-sm hover:text-foreground"
+              >
+                View all
+              </Link>
+            )
+          }
+        >
+          {recentAds.length === 0 ? (
+            <EmptyNote icon={<CodeXmlIcon />}>
+              No ads yet — drop the{" "}
+              <Link
+                to="/$workspaceId/embed"
+                params={{ workspaceId }}
+                className="font-medium underline decoration-border underline-offset-4 hover:decoration-foreground"
+              >
+                tier selector
+              </Link>{" "}
+              on your site to get your first advertiser.
+            </EmptyNote>
+          ) : (
+            <div className="flex flex-col divide-y">
+              {recentAds.map(ad => (
+                <DashboardAdRow key={ad.id} workspaceId={workspaceId} ad={ad} showStatus>
+                  {ad.tier.name} · {ad.advertiser.email ?? ad.advertiser.name}
+                </DashboardAdRow>
+              ))}
+            </div>
+          )}
+        </ListCard>
+      </div>
+    </>
+  )
+}
+
+type MetricProps = ComponentProps<"div"> & {
+  label: string
+  value: string | number
+  hint?: string
+}
+
+const Metric = ({ label, value, hint, className, ...props }: MetricProps) => {
+  return (
+    <div className={cx("min-w-0 p-4", className)} {...props}>
+      <p className="text-muted-foreground text-xs uppercase tracking-wide">{label}</p>
+      <p className="mt-1 truncate font-display text-2xl font-semibold tabular-nums">
+        {typeof value === "number" ? formatNumber(value, "standard") : value}
+      </p>
+      {hint && <p className="truncate text-muted-foreground text-xs">{hint}</p>}
+    </div>
+  )
+}
+
+type ListCardProps = {
+  title: string
+  count: number
+  action?: ReactNode
+  children: ReactNode
+}
+
+const ListCard = ({ title, count, action, children }: ListCardProps) => {
+  return (
+    <Card>
+      <Card.Panel className="flex items-center gap-2 px-4 py-3">
+        <H5>{title}</H5>
+        <Badge variant="secondary">{count}</Badge>
+        <div className="ml-auto">{action}</div>
+      </Card.Panel>
+
+      <Card.Panel>{children}</Card.Panel>
+    </Card>
+  )
+}
+
+const EmptyNote = ({ icon, children }: { icon: ReactNode; children: ReactNode }) => {
+  return (
+    <div className="flex items-center gap-2.5 px-4 py-6 text-muted-foreground text-sm">
+      <span className="shrink-0 [&_svg]:size-4.5">{icon}</span>
+      <p>{children}</p>
+    </div>
+  )
+}
+
+type DashboardAdRowProps = {
+  workspaceId: string
+  ad: DashboardAd
+  showStatus?: boolean
+  children: ReactNode
+}
+
+const DashboardAdRow = ({ workspaceId, ad, showStatus, children }: DashboardAdRowProps) => {
+  const serving = getServingState(ad)
+
+  return (
+    <div className="relative flex items-center gap-3 px-4 py-3 hover:bg-muted/50">
+      <span className="relative shrink-0">
+        <Avatar className="size-9 rounded-md border">
+          <AvatarImage src={faviconUrl(ad.websiteUrl)} className="p-1" />
+          <AvatarFallback className="rounded-none text-xs">{getInitials(ad.name)}</AvatarFallback>
+        </Avatar>
+
+        <span
+          className="-right-0.5 -bottom-0.5 absolute rounded-full bg-background p-0.5"
+          title={serving.detail}
+        >
+          <ServingDot state={serving} />
+        </span>
+      </span>
+
+      <Link
+        to="/$workspaceId/ads/$adId"
+        params={{ workspaceId, adId: ad.id }}
+        className="min-w-0 flex-1"
+      >
+        <span className="flex items-center gap-2">
+          <H5 className="truncate">{ad.name}</H5>
+          {showStatus && <Badge variant={adStatusVariant[ad.status]}>{ad.status}</Badge>}
+        </span>
+        <span className="block truncate text-muted-foreground text-sm">{children}</span>
+        <span className="absolute inset-0" />
+      </Link>
+    </div>
   )
 }

--- a/bun.lock
+++ b/bun.lock
@@ -80,6 +80,7 @@
         "react-day-picker": "^9.14.0",
         "react-dom": "^19.2.6",
         "react-hook-form": "^7.75.0",
+        "recharts": "^3.8.1",
         "sonner": "^2.0.7",
         "stripe": "^22.2.0",
         "zod": "^4.4.3",

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -80,6 +80,14 @@ const seed = async () => {
     })
   }
 
+  // Re-runs recreate the workspace under a new id, so repoint any default
+  // that is unset or left dangling by the wipe above.
+  const workspaceIds = (await db.workspace.findMany({ select: { id: true } })).map(w => w.id)
+  await db.user.updateMany({
+    where: { OR: [{ defaultWorkspaceId: null }, { defaultWorkspaceId: { notIn: workspaceIds } }] },
+    data: { defaultWorkspaceId: workspace.id },
+  })
+
   // ---------------------------------------------------------------- Fields
   const fieldData = [
     { type: "Text", name: "Tagline", placeholder: "One-liner shown on the card", isRequired: true },
@@ -250,7 +258,8 @@ const seed = async () => {
     {
       advertiser: { name: "ShadyVPN", email: "marketing@shadyvpn.example" },
       price: "Silver/Month/2900",
-      subscription: { status: "Active" },
+      // Rejecting an ad cancels its subscription — keep the pair consistent
+      subscription: { status: "Canceled" },
       ad: {
         name: "ShadyVPN",
         websiteUrl: "https://shadyvpn.example",
@@ -347,8 +356,13 @@ const seed = async () => {
   for (const item of adSeeds) {
     subSeq += 1
 
+    // Submission always predates the review decision, and the advertiser
+    // record is created at checkout time alongside the subscription.
+    const reviewedDaysAgo = item.ad.status === "Approved" ? (item.ad.approvedDaysAgo ?? 7) : 2
+    const submittedAt = new Date(Date.now() - (reviewedDaysAgo + 3) * DAY)
+
     const advertiser = await db.advertiser.create({
-      data: { ...item.advertiser, workspaceId: workspace.id },
+      data: { ...item.advertiser, createdAt: submittedAt, workspaceId: workspace.id },
     })
 
     const price = prices[item.price]
@@ -364,6 +378,7 @@ const seed = async () => {
         stripeCustomerId: `cus_seed${String(subSeq).padStart(4, "0")}`,
         status: item.subscription.status,
         cancelAtPeriodEnd: item.subscription.cancelAtPeriodEnd ?? false,
+        createdAt: submittedAt,
         currentPeriodStart: periodStart,
         currentPeriodEnd: periodEnd,
         workspaceId: workspace.id,
@@ -378,10 +393,9 @@ const seed = async () => {
         name: item.ad.name,
         websiteUrl: item.ad.websiteUrl,
         status: item.ad.status,
+        createdAt: submittedAt,
         approvedAt:
-          item.ad.status === "Approved"
-            ? new Date(Date.now() - (item.ad.approvedDaysAgo ?? 7) * DAY)
-            : null,
+          item.ad.status === "Approved" ? new Date(Date.now() - reviewedDaysAgo * DAY) : null,
         rejectedAt: item.ad.status === "Rejected" ? new Date(Date.now() - 2 * DAY) : null,
         rejectionNote: item.ad.rejectionNote,
         subscriptionId: subscription.id,

--- a/packages/db/src/schema/ad.ts
+++ b/packages/db/src/schema/ad.ts
@@ -2,7 +2,8 @@ import { z } from "zod"
 
 export const adCreativeSchema = z.object({
   name: z.string().trim().min(2, { message: "Name is too short" }),
-  websiteUrl: z.url(),
+  // http(s) only — these URLs render as hrefs in the publisher dashboard
+  websiteUrl: z.url({ protocol: /^https?$/, message: "Must be a valid http(s) URL" }),
 })
 
 export type AdCreativeSchema = z.infer<typeof adCreativeSchema>

--- a/packages/orpc/src/router.ts
+++ b/packages/orpc/src/router.ts
@@ -2,6 +2,7 @@ import type { InferRouterInputs, InferRouterOutputs, RouterClient } from "@orpc/
 import { adRouter, getCurrentAds, recordClick, recordImpression } from "./routers/ad"
 import { advertiserRouter } from "./routers/advertiser"
 import { authRouter } from "./routers/auth"
+import { dashboardRouter } from "./routers/dashboard"
 import { fieldRouter } from "./routers/field"
 import { onboardingRouter } from "./routers/onboarding"
 import { storageRouter } from "./routers/storage"
@@ -24,6 +25,7 @@ export const appRouter = {
   user: userRouter,
   onboarding: onboardingRouter,
   workspace: workspaceRouter,
+  dashboard: dashboardRouter,
   field: fieldRouter,
   tier: tierRouter,
   tierPrice: tierPriceRouter,

--- a/packages/orpc/src/routers/ad.ts
+++ b/packages/orpc/src/routers/ad.ts
@@ -17,7 +17,8 @@ const createFromCheckoutInput = z.object({
   workspaceId: z.string().min(1),
   sessionId: z.string().min(1),
   name: z.string().trim().min(2),
-  websiteUrl: z.url(),
+  // http(s) only — rendered as hrefs in the publisher dashboard
+  websiteUrl: z.url({ protocol: /^https?$/ }),
   meta: z
     .array(z.object({ fieldId: z.string(), value: z.unknown() }))
     .optional()

--- a/packages/orpc/src/routers/dashboard.ts
+++ b/packages/orpc/src/routers/dashboard.ts
@@ -1,0 +1,105 @@
+import type { BillingInterval } from "@openads/db/client"
+import { z } from "zod"
+import { authProcedure, workspaceMw } from "../index"
+
+const MONTHS_PER_INTERVAL: Record<BillingInterval, number> = {
+  Day: 1 / 30,
+  Week: 7 / 30,
+  Month: 1,
+  Year: 12,
+}
+
+const isPaid = (status: string) => status === "Active" || status === "Trialing"
+
+export const dashboardRouter = {
+  /**
+   * Everything the workspace overview needs in one round trip: normalized
+   * monthly revenue, serving/pending counts, a 30-day traffic series summed
+   * across all ads, the review queue, and the latest submissions.
+   */
+  get: authProcedure
+    .input(z.object({ workspaceId: z.string() }))
+    .use(workspaceMw)
+    .handler(async ({ context: { db, workspace } }) => {
+      const since = new Date()
+      since.setUTCHours(0, 0, 0, 0)
+      since.setUTCDate(since.getUTCDate() - 29)
+
+      const [subscriptions, statRows] = await Promise.all([
+        db.subscription.findMany({
+          where: { workspaceId: workspace.id, ad: { isNot: null } },
+          include: { ad: true, tier: true, tierPrice: true, advertiser: true },
+        }),
+        db.adStat.groupBy({
+          by: ["date"],
+          where: {
+            date: { gte: since },
+            ad: { is: { subscription: { is: { workspaceId: workspace.id } } } },
+          },
+          _sum: { impressions: true, clicks: true },
+          orderBy: { date: "asc" },
+        }),
+      ])
+
+      const paid = subscriptions.filter(sub => isPaid(sub.status))
+      const monthlyCents = paid.reduce((total, { tierPrice }) => {
+        const months = MONTHS_PER_INTERVAL[tierPrice.interval] * tierPrice.intervalCount
+        return total + tierPrice.amount / months
+      }, 0)
+
+      const ads = subscriptions.flatMap(({ ad, ...subscription }) => {
+        if (!ad) return []
+        return [
+          {
+            id: ad.id,
+            name: ad.name,
+            websiteUrl: ad.websiteUrl,
+            status: ad.status,
+            createdAt: ad.createdAt,
+            advertiser: {
+              id: subscription.advertiser.id,
+              name: subscription.advertiser.name,
+              email: subscription.advertiser.email,
+            },
+            tier: { name: subscription.tier.name },
+            subscription: { status: subscription.status },
+          },
+        ]
+      })
+
+      const byNewest = [...ads].sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
+
+      const series = statRows.map(row => ({
+        date: row.date,
+        impressions: row._sum.impressions ?? 0,
+        clicks: row._sum.clicks ?? 0,
+      }))
+
+      const totals = series.reduce(
+        (acc, row) => ({
+          impressions: acc.impressions + row.impressions,
+          clicks: acc.clicks + row.clicks,
+        }),
+        { impressions: 0, clicks: 0 },
+      )
+
+      return {
+        revenue: {
+          monthlyCents: Math.round(monthlyCents),
+          currency: paid[0]?.tierPrice.currency ?? "usd",
+          paidSubscriptions: paid.length,
+        },
+        counts: {
+          ads: ads.length,
+          servingAds: ads.filter(ad => ad.status === "Approved" && isPaid(ad.subscription.status))
+            .length,
+          pastDueSubscriptions: subscriptions.filter(sub => sub.status === "PastDue").length,
+          advertisers: new Set(subscriptions.map(sub => sub.advertiserId)).size,
+        },
+        series,
+        totals,
+        pendingAds: byNewest.filter(ad => ad.status === "Pending"),
+        recentAds: byNewest.slice(0, 5),
+      }
+    }),
+}

--- a/packages/ui/src/components/chart.tsx
+++ b/packages/ui/src/components/chart.tsx
@@ -205,7 +205,7 @@ const ChartTooltipContent = ({
                   )}
                   <div
                     className={cx(
-                      "flex flex-1 justify-between leading-none",
+                      "flex flex-1 justify-between gap-4 leading-none",
                       nestLabel ? "items-end" : "items-center",
                     )}
                   >


### PR DESCRIPTION
## Summary

Three connected UI upgrades sharing one visual vocabulary, plus the backend procedure and seed improvements they surfaced.

### Ad review page (`/ads/$adId`)
- Creative presented as a reviewable dossier: definition-list layout, favicon header, type-aware custom field rendering (images on dashed backdrop with click-through, switches as Yes/No badges, every workspace field shown — empty ones as "—")
- Sticky review rail with a **serving-state indicator** that collapses the approved-creative × paid-subscription rule into one glanceable signal (pulsing green dot when in rotation), a submitted/reviewed timeline, and the previously-invisible last review note
- Stats table replaced by a metric strip + recharts area chart with hover tooltips

### Advertiser detail page (`/advertisers/$advertiserId`)
- Leads with **monthly revenue** normalized from the advertiser's paid subscriptions
- Ad rows gain favicon avatars with presence-style serving dots, tier + billing, renews/ends dates, and tabular stats
- Email action in the header

### Workspace dashboard (`/`)
- Replaces the empty stub; fed by a new `dashboard.get` oRPC procedure (one round trip: normalized MRR, serving/pending counts, 30-day workspace-wide traffic series via a single `adStat` groupBy, review queue, latest submissions)
- Metric strip → performance chart → review queue + latest ads cards, with empty states and a setup nudge to the embed page for fresh workspaces

### Shared components
- `~/components/ads/serving-state.tsx` — `getServingState` + `ServingDot`, used by all three pages
- `~/components/stats/performance-chart.tsx` — extracted from ad-stats, used by ad page + dashboard
- `recharts` added as a direct `apps/app` dependency (was only declared in `@openads/ui`)

### Seed improvements
- Backdated advertiser/subscription/ad `createdAt` so submissions predate review decisions
- Rejected ad's subscription is now Canceled (matches product behavior)
- Re-runs repair dangling `user.defaultWorkspaceId`

## Test plan
- [x] Lint, typecheck, and full test suite pass (22 tests)
- [x] Screenshot-verified in the running app against seeded data: pending / approved-with-stats / rejected-with-note ads, long-content stress records, advertiser revenue + canceled states, dashboard with full and seeded data
- [x] Light and dark mode verified on all three pages