### PR TITLE
feat: re-host workspace and ad favicons from context.dev on R2

### DIFF
--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -15,6 +15,8 @@ export const env = createEnv({
     PORT: z.coerce.number().default(3001),
     APP_URL: z.url(),
     API_URL: z.url(),
+    // context.dev Logo Link public client id (brandLL_...), used to source favicons.
+    LOGO_LINK_CLIENT_ID: z.string().min(1),
   },
 
   runtimeEnv: process.env,

--- a/apps/api/src/services/s3.ts
+++ b/apps/api/src/services/s3.ts
@@ -1,13 +1,3 @@
-import { type S3BucketClient, createS3BucketClient } from "@openads/s3"
-import { env } from "~/env"
+import { type S3BucketClient, createS3BucketClientFromEnv } from "@openads/s3"
 
-export const s3: S3BucketClient = createS3BucketClient({
-  region: env.S3_REGION,
-  bucket: env.S3_BUCKET,
-  accessKeyId: env.S3_ACCESS_KEY_ID,
-  secretAccessKey: env.S3_SECRET_ACCESS_KEY,
-  endpoint: env.S3_ENDPOINT,
-  forcePathStyle: env.S3_FORCE_PATH_STYLE,
-  publicUrl: env.S3_PUBLIC_URL,
-  signedUrlTtlSeconds: env.S3_SIGNED_URL_TTL,
-})
+export const s3: S3BucketClient = createS3BucketClientFromEnv()

--- a/apps/app/src/components/nav-button.tsx
+++ b/apps/app/src/components/nav-button.tsx
@@ -16,7 +16,7 @@ const NavButton = ({ className, avatar, title, subtitle, ...props }: NavButtonPr
     <Button size="sm" variant="ghost" className={cx("gap-3", className)} {...props}>
       <Avatar className="size-8 md:size-10">
         <AvatarImage src={avatar} />
-        <AvatarFallback>{getInitials(title)}</AvatarFallback>
+        <AvatarFallback>{getInitials(title, 3)}</AvatarFallback>
       </Avatar>
 
       <div className="grid gap-1 flex-1 text-left text-sm/tight">

--- a/apps/app/src/components/workspaces/create-workspace-form.tsx
+++ b/apps/app/src/components/workspaces/create-workspace-form.tsx
@@ -1,11 +1,9 @@
-import { isValidUrl, slugify } from "@dirstack/utils"
+import { slugify } from "@dirstack/utils"
 import { workspaceSchema } from "@openads/db/schema"
-import { Avatar, AvatarImage } from "@openads/ui/avatar"
 import { cx } from "@openads/ui/cva"
 import { DialogFooter } from "@openads/ui/dialog"
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@openads/ui/form"
 import { Input } from "@openads/ui/input"
-import { Stack } from "@openads/ui/stack"
 import { useMutation } from "@tanstack/react-query"
 import type { HTMLAttributes } from "react"
 import { toast } from "sonner"
@@ -14,7 +12,6 @@ import { FormButton } from "~/components/form-button"
 import { useComputedField } from "~/hooks/use-computed-field"
 import { useZodForm } from "~/hooks/use-zod-form"
 import { handleMutationError } from "~/lib/handle-mutation-error"
-import { getWebsiteFavicon } from "~/lib/helpers"
 import { orpc, queryClient, type RouterOutputs } from "~/lib/orpc"
 
 type CreateWorkspaceFormProps = HTMLAttributes<HTMLFormElement> & {
@@ -120,17 +117,9 @@ export const CreateWorkspaceForm = ({
             <FormItem className="col-span-full">
               <FormLabel>Website URL</FormLabel>
 
-              <Stack className="w-full" wrap={false}>
-                <FormControl>
-                  <Input type="url" placeholder="https://acme.com" {...field} />
-                </FormControl>
-
-                {isValidUrl(field.value) && (
-                  <Avatar className="size-8">
-                    <AvatarImage src={getWebsiteFavicon(field.value)} />
-                  </Avatar>
-                )}
-              </Stack>
+              <FormControl>
+                <Input type="url" placeholder="https://acme.com" {...field} />
+              </FormControl>
 
               <FormMessage />
             </FormItem>

--- a/apps/app/src/lib/helpers.ts
+++ b/apps/app/src/lib/helpers.ts
@@ -1,2 +1,0 @@
-export const getWebsiteFavicon = (url: string): string =>
-  `https://www.google.com/s2/favicons?sz=128&domain_url=${encodeURIComponent(url)}`

--- a/apps/app/src/lib/workspaces.ts
+++ b/apps/app/src/lib/workspaces.ts
@@ -1,8 +1,6 @@
 import type { Workspace } from "@openads/db/client"
-import { getWebsiteFavicon } from "~/lib/helpers"
 
 export const getWorkspaceFaviconUrl = (workspace: Workspace | undefined) => {
-  if (!workspace) return undefined
-
-  return workspace.faviconUrl || getWebsiteFavicon(workspace.websiteUrl)
+  // Empty string means the favicon was never fetched — let the fallback render.
+  return workspace?.faviconUrl || undefined
 }

--- a/apps/app/src/routes/$workspaceId/account/-components/profile-form.tsx
+++ b/apps/app/src/routes/$workspaceId/account/-components/profile-form.tsx
@@ -147,7 +147,7 @@ export const AccountProfileForm = ({ user, ...props }: AccountProfileFormProps) 
               <Stack size="lg" direction="column">
                 <Avatar className="size-14">
                   <AvatarImage src={previewUrl ?? undefined} />
-                  <AvatarFallback>{getInitials(user.name)}</AvatarFallback>
+                  <AvatarFallback>{getInitials(user.name, 3)}</AvatarFallback>
                 </Avatar>
 
                 <Stack size="sm">

--- a/apps/app/src/routes/$workspaceId/ads/$adId.tsx
+++ b/apps/app/src/routes/$workspaceId/ads/$adId.tsx
@@ -52,14 +52,6 @@ const subscriptionVariant: Record<
   Paused: "secondary",
 }
 
-const faviconUrl = (websiteUrl: string) => {
-  try {
-    return `https://www.google.com/s2/favicons?sz=128&domain=${new URL(websiteUrl).hostname}`
-  } catch {
-    return undefined
-  }
-}
-
 function AdReviewPage() {
   const { workspaceId, adId } = Route.useParams()
   const { ad: initial, fields } = Route.useLoaderData()
@@ -118,8 +110,8 @@ function AdReviewPage() {
       <Header>
         <div className="flex min-w-0 items-center gap-3">
           <Avatar className="size-11 rounded-md border">
-            <AvatarImage src={faviconUrl(ad.websiteUrl)} className="p-1.5" />
-            <AvatarFallback className="rounded-none">{getInitials(ad.name)}</AvatarFallback>
+            <AvatarImage src={ad.faviconUrl || undefined} className="p-1.5" />
+            <AvatarFallback className="rounded-none">{getInitials(ad.name, 3)}</AvatarFallback>
           </Avatar>
 
           <div className="min-w-0">

--- a/apps/app/src/routes/$workspaceId/advertisers/$advertiserId.tsx
+++ b/apps/app/src/routes/$workspaceId/advertisers/$advertiserId.tsx
@@ -75,14 +75,6 @@ const getMonthlyRevenue = (ads: AdvertiserAd[]) => {
   return formatPrice(Math.round(cents), paid[0]!.subscription.tierPrice.currency)
 }
 
-const faviconUrl = (websiteUrl: string) => {
-  try {
-    return `https://www.google.com/s2/favicons?sz=128&domain=${new URL(websiteUrl).hostname}`
-  } catch {
-    return undefined
-  }
-}
-
 function AdvertiserDetailPage() {
   const { workspaceId, advertiserId } = Route.useParams()
   const initial = Route.useLoaderData()
@@ -115,12 +107,12 @@ function AdvertiserDetailPage() {
                 <Avatar className="size-11 rounded-md border">
                   {advertiser.latestAd && (
                     <AvatarImage
-                      src={faviconUrl(advertiser.latestAd.websiteUrl)}
+                      src={advertiser.latestAd.faviconUrl || undefined}
                       className="p-1.5"
                     />
                   )}
                   <AvatarFallback className="rounded-none">
-                    {getInitials(advertiser.name)}
+                    {getInitials(advertiser.name, 3)}
                   </AvatarFallback>
                 </Avatar>
 
@@ -236,8 +228,10 @@ const AdvertiserAdRow = ({ workspaceId, ad, className, ...props }: AdvertiserAdR
       >
         <span className="relative shrink-0">
           <Avatar className="size-9 rounded-md border">
-            <AvatarImage src={faviconUrl(ad.websiteUrl)} className="p-1" />
-            <AvatarFallback className="rounded-none text-xs">{getInitials(ad.name)}</AvatarFallback>
+            <AvatarImage src={ad.faviconUrl || undefined} className="p-1" />
+            <AvatarFallback className="rounded-none text-xs">
+              {getInitials(ad.name, 3)}
+            </AvatarFallback>
           </Avatar>
 
           {/* Presence-style serving indicator, anchored to the favicon */}

--- a/apps/app/src/routes/$workspaceId/advertisers/index.tsx
+++ b/apps/app/src/routes/$workspaceId/advertisers/index.tsx
@@ -84,7 +84,7 @@ const AdvertiserRow = ({ workspaceId, advertiser, className, ...props }: Adverti
       >
         <div className="flex min-w-0 items-center gap-3">
           <Avatar className="size-9">
-            <AvatarFallback>{getInitials(advertiser.name)}</AvatarFallback>
+            <AvatarFallback>{getInitials(advertiser.name, 3)}</AvatarFallback>
           </Avatar>
 
           <div className="min-w-0">

--- a/apps/app/src/routes/$workspaceId/index.tsx
+++ b/apps/app/src/routes/$workspaceId/index.tsx
@@ -42,14 +42,6 @@ const adStatusVariant: Record<DashboardAd["status"], "secondary" | "success" | "
   Rejected: "danger",
 }
 
-const faviconUrl = (websiteUrl: string) => {
-  try {
-    return `https://www.google.com/s2/favicons?sz=128&domain=${new URL(websiteUrl).hostname}`
-  } catch {
-    return undefined
-  }
-}
-
 function DashboardPage() {
   const workspace = useWorkspace()
   const navigate = useNavigate({ from: Route.fullPath })
@@ -291,8 +283,10 @@ const DashboardAdRow = ({ workspaceId, ad, showStatus, children }: DashboardAdRo
     <div className="relative flex items-center gap-3 px-4 py-3 hover:bg-muted/50">
       <span className="relative shrink-0">
         <Avatar className="size-9 rounded-md border">
-          <AvatarImage src={faviconUrl(ad.websiteUrl)} className="p-1" />
-          <AvatarFallback className="rounded-none text-xs">{getInitials(ad.name)}</AvatarFallback>
+          <AvatarImage src={ad.faviconUrl || undefined} className="p-1" />
+          <AvatarFallback className="rounded-none text-xs">
+            {getInitials(ad.name, 3)}
+          </AvatarFallback>
         </Avatar>
 
         <span

--- a/bun.lock
+++ b/bun.lock
@@ -165,6 +165,7 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
+        "@openads/s3": "*",
         "@openads/tsconfig": "*",
         "@types/node": "^25.8.0",
         "prisma": "^7.8.0",
@@ -482,23 +483,23 @@
 
     "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
 
-    "@better-auth/core": ["@better-auth/core@1.6.16", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.39.0", "@standard-schema/spec": "^1.1.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/utils": "0.4.1", "@better-fetch/fetch": "1.2.2", "@cloudflare/workers-types": ">=4", "@opentelemetry/api": "^1.9.0", "better-call": "1.3.6", "jose": "^6.1.0", "kysely": "^0.28.5 || ^0.29.0", "nanostores": "^1.0.1" }, "optionalPeers": ["@cloudflare/workers-types", "@opentelemetry/api"] }, "sha512-a0+ZNaaYYxOdFXFXmOE36TgtYN8QDzSYDozaAH0zsiWB0oyljsENyCxHJSekysISftb0rFpVXNdw525aEAOa6w=="],
+    "@better-auth/core": ["@better-auth/core@1.6.17", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.39.0", "@standard-schema/spec": "^1.1.0", "zod": "^4.3.6" }, "peerDependencies": { "@better-auth/utils": "0.4.1", "@better-fetch/fetch": "1.3.0", "@cloudflare/workers-types": ">=4", "@opentelemetry/api": "^1.9.0", "better-call": "1.3.6", "jose": "^6.1.0", "kysely": "^0.28.5 || ^0.29.0", "nanostores": "^1.0.1" }, "optionalPeers": ["@cloudflare/workers-types", "@opentelemetry/api"] }, "sha512-ithzeL/IKsBEYeCDJs9r1KE2nwYC/6ni8oMA8NCCtP18RoCOiWErFSjrnL+XLaN6zxrB0ko7QxREjyzTNBtusQ=="],
 
-    "@better-auth/drizzle-adapter": ["@better-auth/drizzle-adapter@1.6.16", "", { "peerDependencies": { "@better-auth/core": "^1.6.16", "@better-auth/utils": "0.4.1", "drizzle-orm": "^0.45.2" }, "optionalPeers": ["drizzle-orm"] }, "sha512-AZjswadpR7zlQduj3fRSsu1R5ldQRR9AeFqoxXRI4colrQhevOVY+tJr8RTJv9Nh18e9FMYDXUju2GX+QWHDzg=="],
+    "@better-auth/drizzle-adapter": ["@better-auth/drizzle-adapter@1.6.17", "", { "peerDependencies": { "@better-auth/core": "^1.6.17", "@better-auth/utils": "0.4.1", "drizzle-orm": "^0.45.2" }, "optionalPeers": ["drizzle-orm"] }, "sha512-Dq52cdZ0vREalUwbP8GXBbpk7XTSw5rZtY8n3nTTwrU09RELsXTi0oYQRW62MFYaUqw0mCHIT4H0emAH/5hy5Q=="],
 
-    "@better-auth/kysely-adapter": ["@better-auth/kysely-adapter@1.6.16", "", { "peerDependencies": { "@better-auth/core": "^1.6.16", "@better-auth/utils": "0.4.1", "kysely": "^0.28.17 || ^0.29.0" }, "optionalPeers": ["kysely"] }, "sha512-ys/feL1p6By3/rQlMZ8QTgf9K2tZAIp1p+fGqT2krIoG5r+UsH3gMkUdbHlYxLt790Bo+Njkiqt59P0BMNsi+g=="],
+    "@better-auth/kysely-adapter": ["@better-auth/kysely-adapter@1.6.17", "", { "peerDependencies": { "@better-auth/core": "^1.6.17", "@better-auth/utils": "0.4.1", "kysely": "^0.28.17 || ^0.29.0" }, "optionalPeers": ["kysely"] }, "sha512-rhDrpzyGtogEDrJ3Id+nbOUVtT1DxMF9OFl2EwyktUuvTFyCrefClBdvVbmeYZPva9+ERuOsbjma+E9E0SJ0RA=="],
 
-    "@better-auth/memory-adapter": ["@better-auth/memory-adapter@1.6.16", "", { "peerDependencies": { "@better-auth/core": "^1.6.16", "@better-auth/utils": "0.4.1" } }, "sha512-8mDqe+2PMF9hUxjGNP1NOcqU1AqjUgmE8YC1HTtxa+LjnO7zsAPSxGSyo1L+7buFNLtiNyGFxccHpwOkO4/Msw=="],
+    "@better-auth/memory-adapter": ["@better-auth/memory-adapter@1.6.17", "", { "peerDependencies": { "@better-auth/core": "^1.6.17", "@better-auth/utils": "0.4.1" } }, "sha512-7oU+Gkve7RivIfQkclIet8+qJON6tbbRINihmgGoi67uGPTeEdTy2UixF8R8+lv91gI/Aqea2oNg/MKIalhlIA=="],
 
-    "@better-auth/mongo-adapter": ["@better-auth/mongo-adapter@1.6.16", "", { "peerDependencies": { "@better-auth/core": "^1.6.16", "@better-auth/utils": "0.4.1", "mongodb": "^6.0.0 || ^7.0.0" }, "optionalPeers": ["mongodb"] }, "sha512-JbUg/v3m9WUX94ivVdUOF8t/w2mWNBWvqYMqyWybfHQEPR8cvcqsqpfYvwg9HLBrYwhKXBS3KcJ1Rtk6gZ19Yw=="],
+    "@better-auth/mongo-adapter": ["@better-auth/mongo-adapter@1.6.17", "", { "peerDependencies": { "@better-auth/core": "^1.6.17", "@better-auth/utils": "0.4.1", "mongodb": "^6.0.0 || ^7.0.0" }, "optionalPeers": ["mongodb"] }, "sha512-nSmolHUVR2/AIKg6WijrSxdF9DCAybbiswulw9ph4FghuCuWl9DDzfTKvG/z+/FpRaYuY+KYFitNbeRiTonn1A=="],
 
-    "@better-auth/prisma-adapter": ["@better-auth/prisma-adapter@1.6.16", "", { "peerDependencies": { "@better-auth/core": "^1.6.16", "@better-auth/utils": "0.4.1", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@prisma/client", "prisma"] }, "sha512-2bIlA7wjBx+4N2QcM32xL/YojRuJpDvskXqT/dGYKToDIEl/7yr12cLYlqeaFLL0O0s5qNZ8jbDtlCz20eogeQ=="],
+    "@better-auth/prisma-adapter": ["@better-auth/prisma-adapter@1.6.17", "", { "peerDependencies": { "@better-auth/core": "^1.6.17", "@better-auth/utils": "0.4.1", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0" }, "optionalPeers": ["@prisma/client", "prisma"] }, "sha512-DW1eEXw39Hv/z34ctfoR6lB3rZRt/+X/m7j74dYTsSUt7TjaIjfhQkN01mYN7+GeLSqzGxJ132N93L7iGutKuA=="],
 
-    "@better-auth/telemetry": ["@better-auth/telemetry@1.6.16", "", { "peerDependencies": { "@better-auth/core": "^1.6.16", "@better-auth/utils": "0.4.1", "@better-fetch/fetch": "1.2.2" } }, "sha512-A782UQvlqZBddw0j2Q6tdroHulIpMlqQh/pbw2up30drLi66jz1ttgShRmryfOLAqN4DHqteuRrSsqDDrsp/pA=="],
+    "@better-auth/telemetry": ["@better-auth/telemetry@1.6.17", "", { "peerDependencies": { "@better-auth/core": "^1.6.17", "@better-auth/utils": "0.4.1", "@better-fetch/fetch": "1.3.0" } }, "sha512-ik7gC4UgdR3Jyb0x7yVzLTfc04x5kfjFbSdOraUbhZUXkOF+/7Ee57SuB2QgfffGEr8xhGHp46sqzF9u2D4qoQ=="],
 
     "@better-auth/utils": ["@better-auth/utils@0.4.1", "", { "dependencies": { "@noble/hashes": "^2.0.1" } }, "sha512-SZBPRPF3z0nBvE5ygOkxae35wnnXPRShmqFo78S+qslLeFoPu/pMgnXAuNKFMMybac3tiLaVg1e3MQW5MC+1iA=="],
 
-    "@better-fetch/fetch": ["@better-fetch/fetch@1.2.2", "", {}, "sha512-xlgQcYROGFgKg5FY7ZLppFmG7rR5Hkmz7tgDuQeR79i5KhKRjr2QC9xsBG2qEGPJJjf9bxzg/NMW2hEUWs5OnA=="],
+    "@better-fetch/fetch": ["@better-fetch/fetch@1.3.0", "", {}, "sha512-Lgkl18IrUURFqa1nE38GNDWXf7XGzfxXQDCE/alCQV0yZ98YrPGtlmW61ch1T4YRt3lxrSAGA+Ft73FzuWWb3A=="],
 
     "@changesets/apply-release-plan": ["@changesets/apply-release-plan@7.1.1", "", { "dependencies": { "@changesets/config": "^3.1.4", "@changesets/get-version-range-type": "^0.4.0", "@changesets/git": "^3.0.4", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "detect-indent": "^6.0.0", "fs-extra": "^7.0.1", "lodash.startcase": "^4.4.0", "outdent": "^0.5.0", "prettier": "^2.7.1", "resolve-from": "^5.0.0", "semver": "^7.5.3" } }, "sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA=="],
 
@@ -1380,7 +1381,7 @@
 
     "baseline-browser-mapping": ["baseline-browser-mapping@2.10.20", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ=="],
 
-    "better-auth": ["better-auth@1.6.16", "", { "dependencies": { "@better-auth/core": "1.6.16", "@better-auth/drizzle-adapter": "1.6.16", "@better-auth/kysely-adapter": "1.6.16", "@better-auth/memory-adapter": "1.6.16", "@better-auth/mongo-adapter": "1.6.16", "@better-auth/prisma-adapter": "1.6.16", "@better-auth/telemetry": "1.6.16", "@better-auth/utils": "0.4.1", "@better-fetch/fetch": "1.2.2", "@noble/ciphers": "^2.1.1", "@noble/hashes": "^2.0.1", "better-call": "1.3.6", "defu": "^6.1.4", "jose": "^6.1.3", "kysely": "^0.28.17 || ^0.29.0", "nanostores": "^1.1.1", "zod": "^4.3.6" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4", "drizzle-orm": "^0.45.2", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-YlBITnH3LIBRD+JpR1XRIToJAVVpoQvZzRc4sm5W0/bnPZKLbsmtXbVWJF3ypo9TVnF6geczJKprG/CsWT07Wg=="],
+    "better-auth": ["better-auth@1.6.17", "", { "dependencies": { "@better-auth/core": "1.6.17", "@better-auth/drizzle-adapter": "1.6.17", "@better-auth/kysely-adapter": "1.6.17", "@better-auth/memory-adapter": "1.6.17", "@better-auth/mongo-adapter": "1.6.17", "@better-auth/prisma-adapter": "1.6.17", "@better-auth/telemetry": "1.6.17", "@better-auth/utils": "0.4.1", "@better-fetch/fetch": "1.3.0", "@noble/ciphers": "^2.1.1", "@noble/hashes": "^2.0.1", "better-call": "1.3.6", "defu": "^6.1.4", "jose": "^6.1.3", "kysely": "^0.28.17 || ^0.29.0", "nanostores": "^1.1.1", "zod": "^4.3.6" }, "peerDependencies": { "@lynx-js/react": "*", "@prisma/client": "^5.0.0 || ^6.0.0 || ^7.0.0", "@sveltejs/kit": "^2.0.0", "@tanstack/react-start": "^1.0.0", "@tanstack/solid-start": "^1.0.0", "better-sqlite3": "^12.0.0", "drizzle-kit": ">=0.31.4", "drizzle-orm": "^0.45.2", "mongodb": "^6.0.0 || ^7.0.0", "mysql2": "^3.0.0", "next": "^14.0.0 || ^15.0.0 || ^16.0.0", "pg": "^8.0.0", "prisma": "^5.0.0 || ^6.0.0 || ^7.0.0", "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0", "solid-js": "^1.0.0", "svelte": "^4.0.0 || ^5.0.0", "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0", "vue": "^3.0.0" }, "optionalPeers": ["@lynx-js/react", "@prisma/client", "@sveltejs/kit", "@tanstack/react-start", "@tanstack/solid-start", "better-sqlite3", "drizzle-kit", "drizzle-orm", "mongodb", "mysql2", "next", "pg", "prisma", "react", "react-dom", "solid-js", "svelte", "vitest", "vue"] }, "sha512-M0XMJ9/KE9hlmuN2Zha1VayShZW5CQifAMPaoz41gtao2la6YpT5KrnL5MAeIAM/3d4DkdYA2BVMY1Gt4iEzHw=="],
 
     "better-call": ["better-call@1.3.6", "", { "dependencies": { "@better-auth/utils": "^0.4.0", "@better-fetch/fetch": "^1.1.21", "rou3": "^0.7.12", "set-cookie-parser": "^3.0.1" }, "peerDependencies": { "zod": "^4.0.0" }, "optionalPeers": ["zod"] }, "sha512-no1jI+h6Bkxs1NVBo4rONbVIzsPjZ8IUu7IHaJBiFwVX1XEQGN8KpHots5fSWmXe9nNyLuLIcgx6WEUcE6EDaA=="],
 
@@ -2373,6 +2374,8 @@
     "ast-kit/@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
 
     "babel-dead-code-elimination/@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
+
+    "better-call/@better-fetch/fetch": ["@better-fetch/fetch@1.2.2", "", {}, "sha512-xlgQcYROGFgKg5FY7ZLppFmG7rR5Hkmz7tgDuQeR79i5KhKRjr2QC9xsBG2qEGPJJjf9bxzg/NMW2hEUWs5OnA=="],
 
     "bun-types/@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -27,6 +27,7 @@
     "zod": "^4.4.3"
   },
   "devDependencies": {
+    "@openads/s3": "*",
     "@openads/tsconfig": "*",
     "@types/node": "^25.8.0",
     "prisma": "^7.8.0",

--- a/packages/db/prisma/models/ad.prisma
+++ b/packages/db/prisma/models/ad.prisma
@@ -11,6 +11,7 @@ model Ad {
   // Fixed creative fields. Everything else lives in Meta.
   name       String
   websiteUrl String
+  faviconUrl String @default("")
 
   approvedAt    DateTime?
   rejectedAt    DateTime?

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -1,3 +1,5 @@
+import { createS3BucketClientFromEnv } from "@openads/s3"
+import { fetchAndUploadFavicon } from "@openads/s3/favicon"
 import { db } from "../src/index"
 
 /**
@@ -28,6 +30,30 @@ const mulberry32 = (seed: number) => () => {
 const utcDate = (daysAgo: number) => {
   const d = new Date(Date.now() - daysAgo * DAY)
   return new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate()))
+}
+
+const s3 = createS3BucketClientFromEnv()
+
+/**
+ * Runs the same favicon pipeline as the create procedures: fetch from the
+ * logo service, re-host on R2, return the CDN URL. Keys are domain-based
+ * (not id-based) so re-runs overwrite instead of orphaning objects. Returns
+ * "" when offline or unconfigured — the UI falls back to initials.
+ */
+const seedFavicon = async (websiteUrl: string): Promise<string> => {
+  const logoLinkClientId = process.env.LOGO_LINK_CLIENT_ID
+  if (!logoLinkClientId) {
+    console.warn("LOGO_LINK_CLIENT_ID not set — seeding without favicons")
+    return ""
+  }
+
+  const url = await fetchAndUploadFavicon(s3, {
+    websiteUrl,
+    logoLinkClientId,
+    key: `seed/favicons/${new URL(websiteUrl).hostname}.png`,
+  }).catch(() => null)
+
+  return url ?? ""
 }
 
 const seed = async () => {
@@ -67,7 +93,7 @@ const seed = async () => {
       name: "Acme Directory",
       slug: WORKSPACE_SLUG,
       websiteUrl: "https://acme.directory",
-      faviconUrl: "https://www.google.com/s2/favicons?sz=64&domain=directories.dev",
+      faviconUrl: await seedFavicon("https://acme.directory"),
       stripeConnectId: "acct_seed0000000000000001",
       stripeConnectStatus: "Active",
       stripeConnectEnabled: true,
@@ -350,6 +376,16 @@ const seed = async () => {
     },
   ]
 
+  // Prefetch all ad favicons concurrently (real domains get logos, fake
+  // `.example` domains get generated monograms).
+  const faviconUrls = new Map(
+    await Promise.all(
+      adSeeds.map(
+        async item => [item.ad.websiteUrl, await seedFavicon(item.ad.websiteUrl)] as const,
+      ),
+    ),
+  )
+
   let subSeq = 0
   let totalStats = 0
 
@@ -392,6 +428,7 @@ const seed = async () => {
       data: {
         name: item.ad.name,
         websiteUrl: item.ad.websiteUrl,
+        faviconUrl: faviconUrls.get(item.ad.websiteUrl) ?? "",
         status: item.ad.status,
         createdAt: submittedAt,
         approvedAt:

--- a/packages/orpc/src/index.ts
+++ b/packages/orpc/src/index.ts
@@ -26,6 +26,7 @@ export type Context = {
   env: {
     APP_URL: string
     API_URL: string
+    LOGO_LINK_CLIENT_ID: string
     STRIPE_CONNECT_CLIENT_ID?: string
     STRIPE_PLATFORM_FEE_PERCENT: number
   }

--- a/packages/orpc/src/lib/ad-serving.test.ts
+++ b/packages/orpc/src/lib/ad-serving.test.ts
@@ -5,6 +5,7 @@ const goldAdRow = {
   id: "ad_gold",
   name: "Acme Gold",
   websiteUrl: "https://acme.test",
+  faviconUrl: "https://cdn.acme.test/workspaces/ws_openads/ads/ad_gold/favicon.png",
   subscription: { tier: { weight: 3 } },
   meta: [
     {
@@ -18,6 +19,7 @@ const silverAdRow = {
   id: "ad_silver",
   name: "Acme Silver",
   websiteUrl: "https://silver.test",
+  faviconUrl: "",
   subscription: { tier: { weight: 1 } },
   meta: [],
 }
@@ -72,7 +74,7 @@ describe("findServingAd", () => {
       id: "ad_gold",
       name: "Acme Gold",
       websiteUrl: "https://acme.test",
-      faviconUrl: "https://www.google.com/s2/favicons?sz=128&domain_url=https%3A%2F%2Facme.test",
+      faviconUrl: "https://cdn.acme.test/workspaces/ws_openads/ads/ad_gold/favicon.png",
       weight: 3,
       meta: { description: "Modern hosting" },
       fields: [

--- a/packages/orpc/src/lib/ad-serving.ts
+++ b/packages/orpc/src/lib/ad-serving.ts
@@ -45,10 +45,6 @@ type FindServingAdsProps = FindServingAdProps & {
   count?: number
 }
 
-const getFaviconUrl = (websiteUrl: string): string => {
-  return `https://www.google.com/s2/favicons?sz=128&domain_url=${encodeURIComponent(websiteUrl)}`
-}
-
 const getMetaRecord = (fields: Array<ServingFieldValue>): Record<string, unknown> => {
   return Object.fromEntries(fields.map(field => [field.name, field.value]))
 }
@@ -81,6 +77,7 @@ const fetchEligibleAds = async ({
       id: true,
       name: true,
       websiteUrl: true,
+      faviconUrl: true,
       subscription: { select: { tier: { select: { weight: true } } } },
       meta: {
         select: {
@@ -103,7 +100,7 @@ const fetchEligibleAds = async ({
       id: row.id,
       name: row.name,
       websiteUrl: row.websiteUrl,
-      faviconUrl: getFaviconUrl(row.websiteUrl),
+      faviconUrl: row.faviconUrl,
       weight: row.subscription.tier.weight,
       meta: getMetaRecord(fields),
       fields,

--- a/packages/orpc/src/routers/ad.public.test.ts
+++ b/packages/orpc/src/routers/ad.public.test.ts
@@ -22,6 +22,7 @@ const adRow = {
   id: "ad_live",
   name: "Acme",
   websiteUrl: "https://acme.test",
+  faviconUrl: "https://cdn.acme.test/workspaces/ws_1/ads/ad_live/favicon.png",
   subscription: { tier: { weight: 3 } },
   meta: [
     {

--- a/packages/orpc/src/routers/ad.ts
+++ b/packages/orpc/src/routers/ad.ts
@@ -329,9 +329,12 @@ const createFromCheckout = publicProcedure
         },
       })
 
-      // Best-effort — failure is logged but doesn't block ad creation.
-      await fetchAndUploadFavicon(s3, {
+      // Best-effort — failure is logged but doesn't block ad creation. The
+      // R2 URL is persisted so serving and dashboards never reference the
+      // third-party logo service directly.
+      const faviconUrl = await fetchAndUploadFavicon(s3, {
         websiteUrl,
+        logoLinkClientId: env.LOGO_LINK_CLIENT_ID,
         key: `workspaces/${workspaceId}/ads/${ad.id}/favicon.png`,
       }).catch(err => {
         logger.warn("ad.createFromCheckout: favicon fetch failed", {
@@ -341,6 +344,10 @@ const createFromCheckout = publicProcedure
         })
         return null
       })
+
+      if (faviconUrl) {
+        await db.ad.update({ where: { id: ad.id }, data: { faviconUrl } })
+      }
 
       // Transactional replace so concurrent reads never see an ad with zero
       // meta rows between the delete and the recreate. Always runs — an empty

--- a/packages/orpc/src/routers/advertiser.ts
+++ b/packages/orpc/src/routers/advertiser.ts
@@ -111,6 +111,7 @@ export const advertiserRouter = {
                 name: latestAd.name,
                 status: latestAd.status,
                 websiteUrl: latestAd.websiteUrl,
+                faviconUrl: latestAd.faviconUrl,
               }
             : null,
           latestTier: latestSubscription
@@ -199,6 +200,7 @@ export const advertiserRouter = {
               name: ad.name,
               status: ad.status,
               websiteUrl: ad.websiteUrl,
+              faviconUrl: ad.faviconUrl,
               createdAt: ad.createdAt,
               updatedAt: ad.updatedAt,
               approvedAt: ad.approvedAt,

--- a/packages/orpc/src/routers/dashboard.ts
+++ b/packages/orpc/src/routers/dashboard.ts
@@ -54,6 +54,7 @@ export const dashboardRouter = {
             id: ad.id,
             name: ad.name,
             websiteUrl: ad.websiteUrl,
+            faviconUrl: ad.faviconUrl,
             status: ad.status,
             createdAt: ad.createdAt,
             advertiser: {

--- a/packages/orpc/src/routers/workspace.ts
+++ b/packages/orpc/src/routers/workspace.ts
@@ -1,9 +1,36 @@
 import { WorkspaceMemberRole } from "@openads/db/client"
 import { idSchema, workspaceSchema } from "@openads/db/schema"
+import { fetchAndUploadFavicon } from "@openads/s3/favicon"
 import { z } from "zod"
-import { authProcedure, workspaceMw } from "../index"
+import { authProcedure, type Context, workspaceMw } from "../index"
 
 const workspaceUpdateInput = workspaceSchema.extend({ workspaceId: z.string() })
+
+/**
+ * Fetches the workspace favicon from the logo service, re-hosts it on R2 and
+ * persists the R2 URL. Best-effort — failure is logged and leaves the
+ * existing `faviconUrl` untouched.
+ */
+const refreshWorkspaceFavicon = async (
+  { db, s3, logger, env }: Pick<Context, "db" | "s3" | "logger" | "env">,
+  { workspaceId, websiteUrl }: { workspaceId: string; websiteUrl: string },
+) => {
+  const faviconUrl = await fetchAndUploadFavicon(s3, {
+    websiteUrl,
+    logoLinkClientId: env.LOGO_LINK_CLIENT_ID,
+    key: `workspaces/${workspaceId}/favicon.png`,
+  }).catch(err => {
+    logger.warn("workspace: favicon fetch failed", { err, workspaceId, websiteUrl })
+    return null
+  })
+
+  if (!faviconUrl) return null
+
+  return await db.workspace.update({
+    where: { id: workspaceId },
+    data: { faviconUrl },
+  })
+}
 
 export const workspaceRouter = {
   getAll: authProcedure.handler(async ({ context: { db, user } }) => {
@@ -21,27 +48,41 @@ export const workspaceRouter = {
       })
     }),
 
-  create: authProcedure
-    .input(workspaceSchema)
-    .handler(async ({ context: { db, user }, input: data }) => {
-      const workspace = await db.workspace.create({
-        data: {
-          ...data,
-          members: { create: { userId: user.id, role: WorkspaceMemberRole.Owner } },
-        },
-      })
+  create: authProcedure.input(workspaceSchema).handler(async ({ context, input: data }) => {
+    const workspace = await context.db.workspace.create({
+      data: {
+        ...data,
+        members: { create: { userId: context.user.id, role: WorkspaceMemberRole.Owner } },
+      },
+    })
 
-      return workspace
-    }),
+    const refreshed = await refreshWorkspaceFavicon(context, {
+      workspaceId: workspace.id,
+      websiteUrl: workspace.websiteUrl,
+    })
+
+    return refreshed ?? workspace
+  }),
 
   update: authProcedure
     .input(workspaceUpdateInput)
     .use(workspaceMw)
-    .handler(async ({ context: { db }, input: { workspaceId, ...data } }) => {
-      const workspace = await db.workspace.update({
+    .handler(async ({ context, input: { workspaceId, ...data } }) => {
+      const websiteUrlChanged = data.websiteUrl !== context.workspace.websiteUrl
+
+      const workspace = await context.db.workspace.update({
         where: { id: workspaceId },
         data,
       })
+
+      if (websiteUrlChanged) {
+        const refreshed = await refreshWorkspaceFavicon(context, {
+          workspaceId,
+          websiteUrl: workspace.websiteUrl,
+        })
+
+        return refreshed ?? workspace
+      }
 
       return workspace
     }),

--- a/packages/s3/src/favicon.ts
+++ b/packages/s3/src/favicon.ts
@@ -2,32 +2,47 @@ import type { S3BucketClient } from "./client"
 
 type FetchAndUploadFaviconProps = {
   websiteUrl: string
+  /** context.dev Logo Link public client id (brandLL_...). */
+  logoLinkClientId: string
   key: string
   cacheControl?: string
 }
 
 /**
- * Fetches a favicon for the given URL via Google's s2/favicons service
- * (handles cases where the site uses `<link rel="icon">` rather than /favicon.ico)
- * and uploads it to the S3 bucket. Returns the public URL of the uploaded asset,
- * or null if the favicon could not be fetched.
+ * Builds a context.dev Logo Link URL for a website. Returns a high-quality
+ * logo when one exists and a generated SVG monogram otherwise, so the
+ * response is always a valid image.
  */
-export async function fetchAndUploadFavicon(
-  s3: S3BucketClient,
-  { websiteUrl, key, cacheControl = "public, max-age=86400" }: FetchAndUploadFaviconProps,
-): Promise<string | null> {
-  let domain: string
+const getLogoUrl = (websiteUrl: string, publicClientId: string): string | null => {
   try {
-    domain = new URL(websiteUrl).hostname
+    const domain = new URL(websiteUrl).hostname
+    return `https://logos.context.dev/?publicClientId=${publicClientId}&domain=${encodeURIComponent(domain)}`
   } catch {
     return null
   }
+}
 
-  const faviconUrl = `https://www.google.com/s2/favicons?domain=${encodeURIComponent(domain)}&sz=128`
+/**
+ * Fetches a favicon for the given website from the logo service and re-hosts
+ * it on the S3 bucket, so clients never reference the third-party URL.
+ * Returns the public URL of the uploaded asset, or null if the website URL is
+ * invalid or the favicon could not be fetched.
+ */
+export async function fetchAndUploadFavicon(
+  s3: S3BucketClient,
+  {
+    websiteUrl,
+    logoLinkClientId,
+    key,
+    cacheControl = "public, max-age=86400",
+  }: FetchAndUploadFaviconProps,
+): Promise<string | null> {
+  const sourceUrl = getLogoUrl(websiteUrl, logoLinkClientId)
+  if (!sourceUrl) return null
 
   let response: Response
   try {
-    response = await fetch(faviconUrl)
+    response = await fetch(sourceUrl)
   } catch {
     return null
   }

--- a/packages/s3/src/index.ts
+++ b/packages/s3/src/index.ts
@@ -1,5 +1,21 @@
+import { createS3BucketClient, type S3BucketClient } from "./client"
+import { env } from "./env"
+
 export { createS3BucketClient, type S3BucketClient } from "./client"
 export { env } from "./env"
+
+/** Creates a bucket client from the package's own validated env vars. */
+export const createS3BucketClientFromEnv = (): S3BucketClient =>
+  createS3BucketClient({
+    region: env.S3_REGION,
+    bucket: env.S3_BUCKET,
+    accessKeyId: env.S3_ACCESS_KEY_ID,
+    secretAccessKey: env.S3_SECRET_ACCESS_KEY,
+    endpoint: env.S3_ENDPOINT,
+    forcePathStyle: env.S3_FORCE_PATH_STYLE,
+    publicUrl: env.S3_PUBLIC_URL,
+    signedUrlTtlSeconds: env.S3_SIGNED_URL_TTL,
+  })
 export type {
   DeleteObjectOptions,
   DeletePrefixOptions,

--- a/packages/sdk/src/index.test.ts
+++ b/packages/sdk/src/index.test.ts
@@ -5,7 +5,7 @@ const sampleAd = {
   id: "ad_123",
   name: "Acme",
   websiteUrl: "https://acme.test",
-  faviconUrl: "https://www.google.com/s2/favicons?sz=128&domain_url=https%3A%2F%2Facme.test",
+  faviconUrl: "https://cdn.acme.test/workspaces/ws_openads/ads/ad_123/favicon.png",
   weight: 2.5,
   meta: { description: "Modern hosting" },
   fields: [


### PR DESCRIPTION
## Summary

Replaces Google's low-quality `s2/favicons` endpoint with **context.dev Logo Link** as the favicon source, and changes the architecture to fetch-once → re-host on R2 → serve from our own CDN. Third-party logo URLs never appear in `<img src>` attributes or API responses.

### Favicon pipeline
- `fetchAndUploadFavicon` (`@openads/s3`) now builds the context.dev source URL internally (`{ websiteUrl, logoLinkClientId, key }`), fetches the logo (real logo or generated SVG monogram — always a valid image), and uploads it to R2
- New `Ad.faviconUrl` column; `ad.createFromCheckout` persists the R2 URL it previously discarded (resubmission refreshes it)
- `workspace.create` fetches + stores the workspace favicon; `workspace.update` re-fetches when the website URL changes
- Ad serving (`/v1` + SDK), dashboard, advertiser, and ad detail responses return the stored R2 URL
- All client-side favicon URL building removed (`getWebsiteFavicon` + 3 duplicated route-local helpers deleted)
- New required server env var: `LOGO_LINK_CLIENT_ID` (context.dev Logo Link public client id)
- New `createS3BucketClientFromEnv()` shared by the API service and the seed
- Seed runs the same pipeline with stable domain-based keys (`seed/favicons/{hostname}.png`) so re-runs overwrite instead of orphaning objects; degrades to initials fallback when offline/unconfigured

### UI
- Removed the favicon preview from the create-workspace (onboarding) form
- Clamped avatar initials to 3 characters via `getInitials(name, 3)` (fixes overflow on long advertiser names)

## Testing
- All 22 tests pass; lint, typecheck (17 tasks), and build green
- Verified context.dev fetch works server-side (no Origin header needed); monogram fallback confirmed for domains without logos
- Full roundtrip smoke-tested: fetch → R2 upload → `cdn.openads.co` serves `image/png` → cleanup
- Reseeded: workspace + 8/8 ads hold `cdn.openads.co` URLs; real domains return PNG logos, fake `.example` domains return SVG monograms