### PR TITLE
refactor(app): dedupe status badges, metric tiles, and ad avatars

### DIFF
--- a/apps/app/src/components/ads/ad-avatar.tsx
+++ b/apps/app/src/components/ads/ad-avatar.tsx
@@ -1,0 +1,31 @@
+import { getInitials } from "@dirstack/utils"
+import { Avatar, AvatarFallback, AvatarImage } from "@openads/ui/avatar"
+import { cx } from "@openads/ui/cva"
+import type { ComponentProps } from "react"
+import { ServingDot, type ServingState } from "~/components/ads/serving-state"
+
+type AdAvatarProps = ComponentProps<"span"> & {
+  ad: { name: string; faviconUrl: string | null }
+  serving?: ServingState
+}
+
+export const AdAvatar = ({ ad, serving, className, ...props }: AdAvatarProps) => {
+  return (
+    <span className={cx("relative shrink-0", className)} {...props}>
+      <Avatar className="size-9 rounded-md border">
+        <AvatarImage src={ad.faviconUrl || undefined} className="p-1" />
+        <AvatarFallback className="rounded-none text-xs">{getInitials(ad.name, 3)}</AvatarFallback>
+      </Avatar>
+
+      {/* Presence-style serving indicator, anchored to the favicon */}
+      {serving && (
+        <span
+          className="-right-0.5 -bottom-0.5 absolute rounded-full bg-background p-0.5"
+          title={serving.detail}
+        >
+          <ServingDot state={serving} />
+        </span>
+      )}
+    </span>
+  )
+}

--- a/apps/app/src/components/ads/ad-row.tsx
+++ b/apps/app/src/components/ads/ad-row.tsx
@@ -1,18 +1,12 @@
-import { Badge } from "@openads/ui/badge"
 import { cx } from "@openads/ui/cva"
 import { Stack } from "@openads/ui/stack"
 import { Link } from "@tanstack/react-router"
 import type { ComponentProps } from "react"
+import { AdStatusBadge } from "~/components/ads/status-badge"
 import { H5 } from "~/components/ui/heading"
 import type { RouterOutputs } from "~/lib/orpc"
 
 type Ad = RouterOutputs["ad"]["getAll"][number]
-
-const statusVariant: Record<Ad["status"], "secondary" | "success" | "danger"> = {
-  Pending: "secondary",
-  Approved: "success",
-  Rejected: "danger",
-}
 
 type AdRowProps = ComponentProps<"div"> & {
   workspaceId: string
@@ -31,7 +25,7 @@ export const AdRow = ({ workspaceId, ad, className, ...props }: AdRowProps) => {
       <Link to="/$workspaceId/ads/$adId" params={{ workspaceId, adId: ad.id }} className="flex-1">
         <Stack size="sm">
           <H5 className="truncate">{ad.name}</H5>
-          <Badge variant={statusVariant[ad.status]}>{ad.status}</Badge>
+          <AdStatusBadge status={ad.status} />
         </Stack>
         <p className="text-muted-foreground text-sm">
           {ad.subscription.advertiser.email ?? ad.subscription.advertiser.name} ·{" "}

--- a/apps/app/src/components/ads/serving-state.tsx
+++ b/apps/app/src/components/ads/serving-state.tsx
@@ -9,7 +9,7 @@ type ServingInput = {
 
 export type ServingState = ReturnType<typeof getServingState>
 
-const isPaid = (status: SubscriptionStatus) => status === "Active" || status === "Trialing"
+export const isPaid = (status: SubscriptionStatus) => status === "Active" || status === "Trialing"
 
 /**
  * An ad serves only when the creative is approved AND the subscription is

--- a/apps/app/src/components/ads/status-badge.tsx
+++ b/apps/app/src/components/ads/status-badge.tsx
@@ -1,0 +1,46 @@
+import type { AdStatus, SubscriptionStatus } from "@openads/db/client"
+import { Badge } from "@openads/ui/badge"
+import type { ComponentProps } from "react"
+
+type BadgeVariant = ComponentProps<typeof Badge>["variant"]
+
+const adStatusVariant: Record<AdStatus, BadgeVariant> = {
+  Pending: "secondary",
+  Approved: "success",
+  Rejected: "danger",
+}
+
+const subscriptionStatusVariant: Record<SubscriptionStatus, BadgeVariant> = {
+  Trialing: "success",
+  Active: "success",
+  PastDue: "warning",
+  Canceled: "secondary",
+  Unpaid: "danger",
+  Incomplete: "warning",
+  IncompleteExpired: "secondary",
+  Paused: "secondary",
+}
+
+type AdStatusBadgeProps = ComponentProps<typeof Badge> & {
+  status: AdStatus
+}
+
+export const AdStatusBadge = ({ status, ...props }: AdStatusBadgeProps) => {
+  return (
+    <Badge variant={adStatusVariant[status]} {...props}>
+      {status}
+    </Badge>
+  )
+}
+
+type SubscriptionStatusBadgeProps = ComponentProps<typeof Badge> & {
+  status: SubscriptionStatus
+}
+
+export const SubscriptionStatusBadge = ({ status, ...props }: SubscriptionStatusBadgeProps) => {
+  return (
+    <Badge variant={subscriptionStatusVariant[status]} {...props}>
+      {status}
+    </Badge>
+  )
+}

--- a/apps/app/src/components/stats/metric.tsx
+++ b/apps/app/src/components/stats/metric.tsx
@@ -1,0 +1,27 @@
+import { formatNumber } from "@dirstack/utils"
+import { cx } from "@openads/ui/cva"
+import type { ComponentProps } from "react"
+
+/** Format a click-through rate as a display string, falling back to a dash. */
+export const formatCtr = (totals: { impressions: number; clicks: number }) => {
+  if (totals.impressions === 0) return "—"
+  return `${((totals.clicks / totals.impressions) * 100).toFixed(2)}%`
+}
+
+type MetricProps = ComponentProps<"div"> & {
+  label: string
+  value: string | number
+  hint?: string
+}
+
+export const Metric = ({ label, value, hint, className, ...props }: MetricProps) => {
+  return (
+    <div className={cx("min-w-0 p-4", className)} {...props}>
+      <p className="text-muted-foreground text-xs uppercase tracking-wide">{label}</p>
+      <p className="mt-1 truncate font-display text-2xl font-semibold tabular-nums">
+        {typeof value === "number" ? formatNumber(value, "standard") : value}
+      </p>
+      {hint && <p className="truncate text-muted-foreground text-xs">{hint}</p>}
+    </div>
+  )
+}

--- a/apps/app/src/routes/$workspaceId/ads/$adId.tsx
+++ b/apps/app/src/routes/$workspaceId/ads/$adId.tsx
@@ -9,7 +9,8 @@ import { ArrowUpRightIcon, CheckIcon, MessageSquareIcon, XIcon } from "lucide-re
 import { type ReactNode, useState } from "react"
 import { toast } from "sonner"
 import { AdStats } from "~/components/ads/ad-stats"
-import { getServingState, ServingDot } from "~/components/ads/serving-state"
+import { getServingState, isPaid, ServingDot } from "~/components/ads/serving-state"
+import { AdStatusBadge, SubscriptionStatusBadge } from "~/components/ads/status-badge"
 import { Card } from "~/components/ui/card"
 import { Header, HeaderActions, HeaderTitle } from "~/components/ui/header"
 import { H5, H6 } from "~/components/ui/heading"
@@ -32,26 +33,6 @@ export const Route = createFileRoute("/$workspaceId/ads/$adId")({
 type Ad = NonNullable<RouterOutputs["ad"]["getById"]>
 type FieldList = RouterOutputs["field"]["getAll"]
 
-const statusVariant: Record<Ad["status"], "secondary" | "success" | "danger"> = {
-  Pending: "secondary",
-  Approved: "success",
-  Rejected: "danger",
-}
-
-const subscriptionVariant: Record<
-  Ad["subscription"]["status"],
-  "secondary" | "success" | "warning" | "danger"
-> = {
-  Trialing: "success",
-  Active: "success",
-  PastDue: "warning",
-  Canceled: "secondary",
-  Unpaid: "danger",
-  Incomplete: "warning",
-  IncompleteExpired: "secondary",
-  Paused: "secondary",
-}
-
 function AdReviewPage() {
   const { workspaceId, adId } = Route.useParams()
   const { ad: initial, fields } = Route.useLoaderData()
@@ -59,7 +40,7 @@ function AdReviewPage() {
   const adQuery = useQuery(
     orpc.ad.getById.queryOptions({ input: { workspaceId, adId }, initialData: initial }),
   )
-  const ad = adQuery.data ?? initial
+  const ad = adQuery.data
   const serving = getServingState(ad)
 
   const [note, setNote] = useState("")
@@ -124,9 +105,7 @@ function AdReviewPage() {
         </div>
 
         <HeaderActions>
-          <Badge variant={statusVariant[ad.status]} size="lg">
-            {ad.status}
-          </Badge>
+          <AdStatusBadge status={ad.status} size="lg" />
 
           {isValidUrl(ad.websiteUrl) && (
             <Button variant="secondary" suffix={<ArrowUpRightIcon />} asChild>
@@ -173,16 +152,13 @@ function AdReviewPage() {
                 <DetailRow label="Billing">
                   <span className="flex flex-wrap items-center gap-2 tabular-nums">
                     {formatTierPrice(tierPrice)}
-                    <Badge variant={subscriptionVariant[subscription.status]}>
-                      {subscription.status}
-                    </Badge>
-                    {subscription.currentPeriodEnd &&
-                      ["Active", "Trialing"].includes(subscription.status) && (
-                        <span className="text-muted-foreground">
-                          {subscription.cancelAtPeriodEnd ? "ends" : "renews"}{" "}
-                          {formatDate(subscription.currentPeriodEnd, "medium", "en-US")}
-                        </span>
-                      )}
+                    <SubscriptionStatusBadge status={subscription.status} />
+                    {subscription.currentPeriodEnd && isPaid(subscription.status) && (
+                      <span className="text-muted-foreground">
+                        {subscription.cancelAtPeriodEnd ? "ends" : "renews"}{" "}
+                        {formatDate(subscription.currentPeriodEnd, "medium", "en-US")}
+                      </span>
+                    )}
                   </span>
                 </DetailRow>
 
@@ -355,7 +331,7 @@ type MetaValueProps = {
 }
 
 const MetaValue = ({ meta, type, name }: MetaValueProps) => {
-  const value = meta?.value as unknown
+  const value = meta?.value
 
   if (value === undefined || value === null || value === "") {
     return <span className="text-muted-foreground">—</span>

--- a/apps/app/src/routes/$workspaceId/advertisers/$advertiserId.tsx
+++ b/apps/app/src/routes/$workspaceId/advertisers/$advertiserId.tsx
@@ -4,13 +4,15 @@ import { Avatar, AvatarFallback, AvatarImage } from "@openads/ui/avatar"
 import { Badge } from "@openads/ui/badge"
 import { Button } from "@openads/ui/button"
 import { cx } from "@openads/ui/cva"
-import { Skeleton } from "@openads/ui/skeleton"
 import { useQuery } from "@tanstack/react-query"
 import { createFileRoute, Link } from "@tanstack/react-router"
 import { ArrowUpRightIcon, MailIcon } from "lucide-react"
 import type { ComponentProps } from "react"
-import { getServingState, ServingDot } from "~/components/ads/serving-state"
+import { AdAvatar } from "~/components/ads/ad-avatar"
+import { getServingState, isPaid } from "~/components/ads/serving-state"
+import { AdStatusBadge, SubscriptionStatusBadge } from "~/components/ads/status-badge"
 import { QueryCell } from "~/components/query-cell"
+import { formatCtr, Metric } from "~/components/stats/metric"
 import { Callout, CalloutText } from "~/components/ui/callout"
 import { Header, HeaderActions, HeaderTitle } from "~/components/ui/header"
 import { H5 } from "~/components/ui/heading"
@@ -30,26 +32,6 @@ export const Route = createFileRoute("/$workspaceId/advertisers/$advertiserId")(
 type Advertiser = RouterOutputs["advertiser"]["getById"]
 type AdvertiserAd = Advertiser["ads"][number]
 
-const adStatusVariant: Record<AdvertiserAd["status"], "secondary" | "success" | "danger"> = {
-  Pending: "secondary",
-  Approved: "success",
-  Rejected: "danger",
-}
-
-const subscriptionVariant: Record<
-  AdvertiserAd["subscription"]["status"],
-  "secondary" | "success" | "warning" | "danger"
-> = {
-  Trialing: "success",
-  Active: "success",
-  PastDue: "warning",
-  Canceled: "secondary",
-  Unpaid: "danger",
-  Incomplete: "warning",
-  IncompleteExpired: "secondary",
-  Paused: "secondary",
-}
-
 const MONTHS_PER_INTERVAL: Record<BillingInterval, number> = {
   Day: 1 / 30,
   Week: 7 / 30,
@@ -62,9 +44,7 @@ const MONTHS_PER_INTERVAL: Record<BillingInterval, number> = {
  * number a publisher actually thinks in. Assumes one currency per workspace.
  */
 const getMonthlyRevenue = (ads: AdvertiserAd[]) => {
-  const paid = ads.filter(
-    ad => ad.subscription.status === "Active" || ad.subscription.status === "Trialing",
-  )
+  const paid = ads.filter(ad => isPaid(ad.subscription.status))
   if (paid.length === 0) return null
 
   const cents = paid.reduce((total, { subscription: { tierPrice } }) => {
@@ -89,7 +69,6 @@ function AdvertiserDetailPage() {
   return (
     <QueryCell
       query={advertiserQuery}
-      pending={() => <Skeleton className="h-96" />}
       error={() => (
         <Callout variant="danger">
           <CalloutText>Could not load advertiser.</CalloutText>
@@ -97,7 +76,6 @@ function AdvertiserDetailPage() {
       )}
       success={({ data: advertiser }) => {
         const { totals } = advertiser
-        const ctr = totals.impressions > 0 ? (totals.clicks / totals.impressions) * 100 : null
         const monthlyRevenue = getMonthlyRevenue(advertiser.ads)
 
         return (
@@ -161,7 +139,7 @@ function AdvertiserDetailPage() {
               <Metric label="30d clicks" value={totals.clicks} />
               <Metric
                 label="30d CTR"
-                value={ctr === null ? "—" : `${ctr.toFixed(2)}%`}
+                value={formatCtr(totals)}
                 className="col-span-2 border-t sm:col-span-1 sm:border-t-0"
               />
             </div>
@@ -185,24 +163,6 @@ function AdvertiserDetailPage() {
   )
 }
 
-type MetricProps = ComponentProps<"div"> & {
-  label: string
-  value: string | number
-  hint?: string
-}
-
-const Metric = ({ label, value, hint, className, ...props }: MetricProps) => {
-  return (
-    <div className={cx("min-w-0 p-4", className)} {...props}>
-      <p className="text-muted-foreground text-xs uppercase tracking-wide">{label}</p>
-      <p className="mt-1 truncate font-display text-2xl font-semibold tabular-nums">
-        {typeof value === "number" ? formatNumber(value, "standard") : value}
-      </p>
-      {hint && <p className="truncate text-muted-foreground text-xs">{hint}</p>}
-    </div>
-  )
-}
-
 type AdvertiserAdRowProps = ComponentProps<"div"> & {
   workspaceId: string
   ad: AdvertiserAd
@@ -211,7 +171,7 @@ type AdvertiserAdRowProps = ComponentProps<"div"> & {
 const AdvertiserAdRow = ({ workspaceId, ad, className, ...props }: AdvertiserAdRowProps) => {
   const { subscription } = ad
   const serving = getServingState(ad)
-  const paid = subscription.status === "Active" || subscription.status === "Trialing"
+  const paid = isPaid(subscription.status)
 
   return (
     <div
@@ -226,27 +186,12 @@ const AdvertiserAdRow = ({ workspaceId, ad, className, ...props }: AdvertiserAdR
         params={{ workspaceId, adId: ad.id }}
         className="flex min-w-0 items-center gap-3"
       >
-        <span className="relative shrink-0">
-          <Avatar className="size-9 rounded-md border">
-            <AvatarImage src={ad.faviconUrl || undefined} className="p-1" />
-            <AvatarFallback className="rounded-none text-xs">
-              {getInitials(ad.name, 3)}
-            </AvatarFallback>
-          </Avatar>
-
-          {/* Presence-style serving indicator, anchored to the favicon */}
-          <span
-            className="-right-0.5 -bottom-0.5 absolute rounded-full bg-background p-0.5"
-            title={serving.detail}
-          >
-            <ServingDot state={serving} />
-          </span>
-        </span>
+        <AdAvatar ad={ad} serving={serving} />
 
         <span className="min-w-0">
           <span className="flex items-center gap-2">
             <H5 className="truncate">{ad.name}</H5>
-            <Badge variant={adStatusVariant[ad.status]}>{ad.status}</Badge>
+            <AdStatusBadge status={ad.status} />
           </span>
           <span className="block truncate text-muted-foreground text-sm">{ad.websiteUrl}</span>
         </span>
@@ -263,7 +208,7 @@ const AdvertiserAdRow = ({ workspaceId, ad, className, ...props }: AdvertiserAdR
 
       <div className="min-w-0 text-sm">
         <p>
-          <Badge variant={subscriptionVariant[subscription.status]}>{subscription.status}</Badge>
+          <SubscriptionStatusBadge status={subscription.status} />
         </p>
         {subscription.currentPeriodEnd && paid && (
           <p className="mt-1 truncate text-muted-foreground tabular-nums">

--- a/apps/app/src/routes/$workspaceId/advertisers/index.tsx
+++ b/apps/app/src/routes/$workspaceId/advertisers/index.tsx
@@ -10,6 +10,7 @@ import { createFileRoute, Link } from "@tanstack/react-router"
 import { SearchIcon, UsersIcon, XIcon } from "lucide-react"
 import { type ComponentProps, useRef, useState } from "react"
 import { z } from "zod"
+import { AdStatusBadge } from "~/components/ads/status-badge"
 import { QueryCell } from "~/components/query-cell"
 import { Callout, CalloutText } from "~/components/ui/callout"
 import { Header, HeaderActions, HeaderTitle } from "~/components/ui/header"
@@ -54,15 +55,6 @@ const AdvertiserSearch = ({ value, onChange }: AdvertiserSearchProps) => {
   )
 }
 
-const statusVariant: Record<
-  NonNullable<Advertiser["latestAd"]>["status"],
-  "secondary" | "success" | "danger"
-> = {
-  Pending: "secondary",
-  Approved: "success",
-  Rejected: "danger",
-}
-
 type AdvertiserRowProps = ComponentProps<"div"> & {
   workspaceId: string
   advertiser: Advertiser
@@ -90,11 +82,7 @@ const AdvertiserRow = ({ workspaceId, advertiser, className, ...props }: Adverti
           <div className="min-w-0">
             <Stack size="sm">
               <H5 className="truncate">{advertiser.name}</H5>
-              {advertiser.latestAd && (
-                <Badge variant={statusVariant[advertiser.latestAd.status]}>
-                  {advertiser.latestAd.status}
-                </Badge>
-              )}
+              {advertiser.latestAd && <AdStatusBadge status={advertiser.latestAd.status} />}
             </Stack>
             <p className="truncate text-muted-foreground text-sm">
               {advertiser.email ?? "No email"} · Latest activity{" "}

--- a/apps/app/src/routes/$workspaceId/index.tsx
+++ b/apps/app/src/routes/$workspaceId/index.tsx
@@ -1,17 +1,18 @@
-import { formatDate, formatNumber, getInitials } from "@dirstack/utils"
-import { Avatar, AvatarFallback, AvatarImage } from "@openads/ui/avatar"
+import { formatDate, formatNumber } from "@dirstack/utils"
 import { Badge } from "@openads/ui/badge"
 import { Button } from "@openads/ui/button"
-import { cx } from "@openads/ui/cva"
 import { Skeleton } from "@openads/ui/skeleton"
 import { useQuery } from "@tanstack/react-query"
 import { createFileRoute, Link, useNavigate } from "@tanstack/react-router"
 import { CheckIcon, CodeXmlIcon } from "lucide-react"
-import type { ComponentProps, ReactNode } from "react"
+import type { ReactNode } from "react"
 import { z } from "zod"
-import { getServingState, ServingDot } from "~/components/ads/serving-state"
+import { AdAvatar } from "~/components/ads/ad-avatar"
+import { getServingState } from "~/components/ads/serving-state"
+import { AdStatusBadge } from "~/components/ads/status-badge"
 import { WelcomeModal } from "~/components/modals/welcome-modal"
 import { QueryCell } from "~/components/query-cell"
+import { formatCtr, Metric } from "~/components/stats/metric"
 import { PerformanceChart } from "~/components/stats/performance-chart"
 import { Callout, CalloutText } from "~/components/ui/callout"
 import { Card } from "~/components/ui/card"
@@ -35,12 +36,6 @@ export const Route = createFileRoute("/$workspaceId/")({
 
 type Dashboard = RouterOutputs["dashboard"]["get"]
 type DashboardAd = Dashboard["recentAds"][number]
-
-const adStatusVariant: Record<DashboardAd["status"], "secondary" | "success" | "danger"> = {
-  Pending: "secondary",
-  Approved: "success",
-  Rejected: "danger",
-}
 
 function DashboardPage() {
   const workspace = useWorkspace()
@@ -97,7 +92,6 @@ function DashboardPage() {
 
 const DashboardBody = ({ workspaceId, data }: { workspaceId: string; data: Dashboard }) => {
   const { revenue, counts, totals, series, pendingAds, recentAds } = data
-  const ctr = totals.impressions > 0 ? (totals.clicks / totals.impressions) * 100 : null
 
   return (
     <>
@@ -122,7 +116,7 @@ const DashboardBody = ({ workspaceId, data }: { workspaceId: string; data: Dashb
           hint={pendingAds.length > 0 ? "needs your decision" : "all caught up"}
         />
         <Metric label="30d impressions" value={totals.impressions} />
-        <Metric label="30d CTR" value={ctr === null ? "—" : `${ctr.toFixed(2)}%`} />
+        <Metric label="30d CTR" value={formatCtr(totals)} />
       </div>
 
       <Card className="animate-slide-up-and-fade [animation-delay:75ms] [animation-fill-mode:backwards]">
@@ -221,24 +215,6 @@ const DashboardBody = ({ workspaceId, data }: { workspaceId: string; data: Dashb
   )
 }
 
-type MetricProps = ComponentProps<"div"> & {
-  label: string
-  value: string | number
-  hint?: string
-}
-
-const Metric = ({ label, value, hint, className, ...props }: MetricProps) => {
-  return (
-    <div className={cx("min-w-0 p-4", className)} {...props}>
-      <p className="text-muted-foreground text-xs uppercase tracking-wide">{label}</p>
-      <p className="mt-1 truncate font-display text-2xl font-semibold tabular-nums">
-        {typeof value === "number" ? formatNumber(value, "standard") : value}
-      </p>
-      {hint && <p className="truncate text-muted-foreground text-xs">{hint}</p>}
-    </div>
-  )
-}
-
 type ListCardProps = {
   title: string
   count: number
@@ -281,21 +257,7 @@ const DashboardAdRow = ({ workspaceId, ad, showStatus, children }: DashboardAdRo
 
   return (
     <div className="relative flex items-center gap-3 px-4 py-3 hover:bg-muted/50">
-      <span className="relative shrink-0">
-        <Avatar className="size-9 rounded-md border">
-          <AvatarImage src={ad.faviconUrl || undefined} className="p-1" />
-          <AvatarFallback className="rounded-none text-xs">
-            {getInitials(ad.name, 3)}
-          </AvatarFallback>
-        </Avatar>
-
-        <span
-          className="-right-0.5 -bottom-0.5 absolute rounded-full bg-background p-0.5"
-          title={serving.detail}
-        >
-          <ServingDot state={serving} />
-        </span>
-      </span>
+      <AdAvatar ad={ad} serving={serving} />
 
       <Link
         to="/$workspaceId/ads/$adId"
@@ -304,7 +266,7 @@ const DashboardAdRow = ({ workspaceId, ad, showStatus, children }: DashboardAdRo
       >
         <span className="flex items-center gap-2">
           <H5 className="truncate">{ad.name}</H5>
-          {showStatus && <Badge variant={adStatusVariant[ad.status]}>{ad.status}</Badge>}
+          {showStatus && <AdStatusBadge status={ad.status} />}
         </span>
         <span className="block truncate text-muted-foreground text-sm">{children}</span>
         <span className="absolute inset-0" />

--- a/apps/app/src/routes/$workspaceId/settings/general/-components/delete-card.tsx
+++ b/apps/app/src/routes/$workspaceId/settings/general/-components/delete-card.tsx
@@ -9,7 +9,7 @@ import { Header, HeaderDescription, HeaderTitle } from "~/components/ui/header"
 import { useWorkspace } from "~/contexts/workspace-context"
 import { orpc, queryClient } from "~/lib/orpc"
 
-export const DeleteForm = (props: ComponentProps<"div">) => {
+export const DeleteWorkspaceCard = (props: ComponentProps<"div">) => {
   const { id, slug } = useWorkspace()
   const navigate = useNavigate()
 

--- a/apps/app/src/routes/$workspaceId/settings/general/-components/id-card.tsx
+++ b/apps/app/src/routes/$workspaceId/settings/general/-components/id-card.tsx
@@ -10,7 +10,7 @@ import { Prose } from "~/components/ui/prose"
 import { siteConfig } from "~/config/site"
 import { useWorkspace } from "~/contexts/workspace-context"
 
-export const IdForm = ({ ...props }: ComponentProps<"div">) => {
+export const WorkspaceIdCard = ({ ...props }: ComponentProps<"div">) => {
   const workspace = useWorkspace()
   const clipboard = useClipboard({ timeout: 3000 })
 

--- a/apps/app/src/routes/$workspaceId/settings/general/-components/stripe-connect-card.tsx
+++ b/apps/app/src/routes/$workspaceId/settings/general/-components/stripe-connect-card.tsx
@@ -4,7 +4,7 @@ import { Card } from "~/components/ui/card"
 import { Header, HeaderDescription, HeaderTitle } from "~/components/ui/header"
 import { useWorkspace } from "~/contexts/workspace-context"
 
-export const StripeConnectForm = ({ ...props }: ComponentProps<"div">) => {
+export const StripeConnectCard = ({ ...props }: ComponentProps<"div">) => {
   const workspace = useWorkspace()
 
   return (

--- a/apps/app/src/routes/$workspaceId/settings/general/index.tsx
+++ b/apps/app/src/routes/$workspaceId/settings/general/index.tsx
@@ -1,9 +1,9 @@
 import { createFileRoute } from "@tanstack/react-router"
 import { Section } from "~/components/ui/section"
-import { DeleteForm } from "~/routes/$workspaceId/settings/general/-components/delete-form"
+import { DeleteWorkspaceCard } from "~/routes/$workspaceId/settings/general/-components/delete-card"
 import { GeneralForm } from "~/routes/$workspaceId/settings/general/-components/general-form"
-import { IdForm } from "~/routes/$workspaceId/settings/general/-components/id-form"
-import { StripeConnectForm } from "~/routes/$workspaceId/settings/general/-components/stripe-connect-form"
+import { WorkspaceIdCard } from "~/routes/$workspaceId/settings/general/-components/id-card"
+import { StripeConnectCard } from "~/routes/$workspaceId/settings/general/-components/stripe-connect-card"
 
 export const Route = createFileRoute("/$workspaceId/settings/general/")({
   component: SettingsGeneralPage,
@@ -13,9 +13,9 @@ function SettingsGeneralPage() {
   return (
     <Section className="mx-auto w-full lg:max-w-3xl">
       <GeneralForm />
-      <IdForm />
-      <StripeConnectForm />
-      <DeleteForm />
+      <WorkspaceIdCard />
+      <StripeConnectCard />
+      <DeleteWorkspaceCard />
     </Section>
   )
 }

--- a/apps/app/src/routes/stripe/callback.tsx
+++ b/apps/app/src/routes/stripe/callback.tsx
@@ -40,12 +40,16 @@ function StripeCallbackPage() {
 
   const errorMessage = searchError ?? completeConnection.error?.message ?? null
 
+  // `mutate` is referentially stable, so the effect only re-fires on real
+  // param changes — the ref guards against StrictMode's double invoke.
+  const { mutate } = completeConnection
+
   useEffect(() => {
     if (hasSubmitted.current || searchError || !search.code || !search.state) return
     hasSubmitted.current = true
 
-    completeConnection.mutate({ code: search.code, state: search.state })
-  }, [completeConnection, search, searchError])
+    mutate({ code: search.code, state: search.state })
+  }, [mutate, search.code, search.state, searchError])
 
   return (
     <div className="grid h-screen place-items-center px-6">


### PR DESCRIPTION
Part of a whole-codebase DHH-style review run via multi-agent workflow: 89 findings survived adversarial verification, applied across 8 themed PRs. Every finding below was checked against the actual code before being fixed.

## Findings addressed

- **[high]** `apps/app/src/routes/$workspaceId/ads/$adId.tsx:35` — **status-badge-variant-map-pasted-five-times**: The same `Pending/Approved/Rejected → secondary/success/danger` lookup is hand-copied in five files ($workspaceId/index.tsx:39, advertisers/index.tsx:57, advertisers/$advertiserId.tsx:33, here, and components/ads/ad-row.tsx:11), and the subscription-status map twice more. Five copies of one domain fact should boil down to one place.
- `apps/app/src/routes/$workspaceId/advertisers/$advertiserId.tsx:194` — **metric-component-duplicated-verbatim**: Metric here is byte-for-byte the same component as Metric in $workspaceId/index.tsx:230 — same props, same classes, same formatNumber branch. Two private copies of one stat tile is how they drift apart.
- `apps/app/src/routes/$workspaceId/index.tsx:284` — **favicon-serving-dot-block-duplicated**: The favicon Avatar with the presence-style ServingDot overlay — including the identical comment — appears here in DashboardAdRow and again in advertisers/$advertiserId.tsx:229. Copy-pasted markup with a copy-pasted comment is the tell.
- `apps/app/src/routes/$workspaceId/ads/$adId.tsx:180` — **paid-subscription-predicate-scattered**: `["Active", "Trialing"].includes(subscription.status)` here, `subscription.status === "Active" || subscription.status === "Trialing"` in advertisers/$advertiserId.tsx:214 — meanwhile serving-state.tsx already owns an `isPaid` that says exactly this but keeps it private. The two-flag serving rule is the core business invariant; it deserves one spelling.
- `apps/app/src/routes/$workspaceId/ads/$adId.tsx:62` — **dead-fallback-behind-initialdata**: `adQuery.data ?? initial` — the query is given `initialData: initial` two lines up, so `data` is always defined. When would the right-hand side ever run? Defensive design.
- `apps/app/src/routes/$workspaceId/advertisers/$advertiserId.tsx:92` — **unreachable-pending-branch**: The query is seeded with `initialData` from the loader, so its status is success from the first render — this `pending={() => <Skeleton className="h-96" />}` branch can never render. Dead skeleton.
- `apps/app/src/routes/$workspaceId/ads/$adId.tsx:358` — **as-unknown-cast-on-json-value**: `const value = meta?.value as unknown` — Meta.value is Prisma `Json`, which already narrows fine through the `typeof value === "string"` checks below. The cast adds nothing but suspicion.
- `apps/app/src/routes/$workspaceId/settings/general/-components/id-form.tsx:13` — **forms-without-form-elements**: IdForm, StripeConnectForm, and DeleteForm contain no `<form>`, no inputs being submitted, no form state — they're settings cards. Names must stand alone; calling a read-only ID display a "Form" sends the reader looking for submit handlers that don't exist.
- `apps/app/src/routes/stripe/callback.tsx:43` — **effect-reruns-every-render-behind-ref-bouncer**: `completeConnection` is a fresh object every render, so this effect fires on every render and only the `hasSubmitted` ref stops repeat mutations. The ref is doing the deps array's job.

## Verification

bun run lint (oxlint: 0 warnings/errors on 263 files), bun run check-types (all 17 turbo tasks pass, including @openads/app cache-miss rebuild), bun test (22 pass, 0 fail across 7 files), bun run format (oxfmt clean). Lefthook pre-commit + commit-msg hooks passed on all three commits.

## Notes

New shared modules: apps/app/src/components/ads/status-badge.tsx (AdStatusBadge + SubscriptionStatusBadge keyed by Prisma AdStatus/SubscriptionStatus enums), apps/app/src/components/ads/ad-avatar.tsx (favicon avatar with optional ServingDot overlay), apps/app/src/components/stats/metric.tsx (Metric tile + formatCtr helper). All five ad-status maps, both subscription-status maps, both Metric copies, both CTR derivations, and both favicon+dot blocks were deleted at their call sites. isPaid is now exported from serving-state.tsx and used in ads/$adId.tsx, advertisers/$advertiserId.tsx (getMonthlyRevenue filter and AdvertiserAdRow). Per the refined fix, the ad review header in ads/$adId.tsx intentionally keeps its own larger (size-11, no dot) Avatar rather than being forced onto AdAvatar. The QueryCell wrapper in advertisers/$advertiserId.tsx was kept (only the dead pending prop removed) so refetch-error UI still renders. Settings renames: IdForm→WorkspaceIdCard (id-card.tsx), StripeConnectForm→StripeConnectCard (stripe-connect-card.tsx), DeleteForm→DeleteWorkspaceCard (delete-card.tsx); GeneralForm unchanged.

## Merge order

Merge this before the oRPC server PR — both touch `$workspaceId/advertisers/$advertiserId.tsx` (different hunks, but this one should land first).
