### PR TITLE
refactor(app): form and flow component cleanups, fix onboarding completion

### DIFF
--- a/apps/app/src/components/ads/image-upload.tsx
+++ b/apps/app/src/components/ads/image-upload.tsx
@@ -3,9 +3,9 @@ import { Button } from "@openads/ui/button"
 import { cx } from "@openads/ui/cva"
 import { useMutation } from "@tanstack/react-query"
 import { ImageIcon, Loader2Icon, TrashIcon } from "lucide-react"
-import { type ChangeEvent, type ComponentProps, useRef, useState } from "react"
+import { type ChangeEvent, type ComponentProps, useRef } from "react"
 import { toast } from "sonner"
-import { orpc } from "~/lib/orpc"
+import { client } from "~/lib/orpc"
 
 type ImageUploadProps = Omit<ComponentProps<"div">, "onChange"> & {
   workspaceId: string
@@ -27,22 +27,10 @@ export const ImageUpload = ({
   ...props
 }: ImageUploadProps) => {
   const inputRef = useRef<HTMLInputElement>(null)
-  const [isUploading, setIsUploading] = useState(false)
 
-  const createUpload = useMutation(orpc.storage.public.createAdvertiserUpload.mutationOptions())
-
-  const handlePick = () => inputRef.current?.click()
-
-  const handleClear = () => onChange(null)
-
-  const handleChange = async (event: ChangeEvent<HTMLInputElement>) => {
-    const file = event.target.files?.[0]
-    event.target.value = "" // allow re-picking the same file
-    if (!file) return
-
-    try {
-      setIsUploading(true)
-      const presigned = await createUpload.mutateAsync({
+  const upload = useMutation({
+    mutationFn: async (file: File) => {
+      const presigned = await client.storage.public.createAdvertiserUpload({
         workspaceId,
         sessionId,
         fileName: file.name,
@@ -52,23 +40,30 @@ export const ImageUpload = ({
 
       // Presigned PUT: send the file as the raw body with the signed headers.
       // The browser sets Content-Length from the body, which the URL also signs.
-      const uploadResponse = await fetch(presigned.uploadUrl, {
+      const res = await fetch(presigned.uploadUrl, {
         method: "PUT",
         headers: presigned.headers,
         body: file,
       })
 
-      if (!uploadResponse.ok) {
-        throw new Error(`Upload failed (${uploadResponse.status})`)
+      if (!res.ok) {
+        throw new Error(`Upload failed (${res.status})`)
       }
 
-      onChange(presigned.publicUrl)
-    } catch (err) {
-      const message = err instanceof Error ? err.message : "Upload failed"
-      toast.error(message)
-    } finally {
-      setIsUploading(false)
-    }
+      return presigned.publicUrl
+    },
+    onSuccess: url => onChange(url),
+    onError: err => toast.error(err instanceof Error ? err.message : "Upload failed"),
+  })
+
+  const handlePick = () => inputRef.current?.click()
+
+  const handleClear = () => onChange(null)
+
+  const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0]
+    event.target.value = "" // allow re-picking the same file
+    if (file) upload.mutate(file)
   }
 
   return (
@@ -103,11 +98,11 @@ export const ImageUpload = ({
         <Button
           type="button"
           variant="secondary"
-          prefix={isUploading ? <Loader2Icon className="animate-spin" /> : <ImageIcon />}
+          prefix={upload.isPending ? <Loader2Icon className="animate-spin" /> : <ImageIcon />}
           onClick={handlePick}
-          disabled={isUploading}
+          disabled={upload.isPending}
         >
-          {isUploading ? "Uploading…" : "Upload image"}
+          {upload.isPending ? "Uploading…" : "Upload image"}
         </Button>
       )}
     </div>

--- a/apps/app/src/components/embed/embed-snippet.tsx
+++ b/apps/app/src/components/embed/embed-snippet.tsx
@@ -26,11 +26,9 @@ const themeLabels: Record<Theme, string> = {
 const PREVIEW_HEIGHT = 640
 
 export const EmbedSnippet = ({ slug }: EmbedSnippetProps) => {
-  const clipboard = useClipboard({ timeout: 2000 })
   const [theme, setTheme] = useState<Theme>("auto")
-  const [copiedSnippet, setCopiedSnippet] = useState("")
 
-  const baseUrl = env.VITE_BASE_URL || (typeof window !== "undefined" ? window.location.origin : "")
+  const baseUrl = env.VITE_BASE_URL
   const apiUrl = env.VITE_API_URL
 
   const url = `${baseUrl}/embed/${slug}?${new URLSearchParams({ theme })}`
@@ -100,11 +98,6 @@ export const Ads = () => (
   </OpenAdsProvider>
 )`
 
-  const copySnippet = (id: string, value: string) => {
-    setCopiedSnippet(id)
-    clipboard.copy(value)
-  }
-
   return (
     <Card>
       <Card.Section>
@@ -159,36 +152,20 @@ export const Ads = () => (
 
       <Card.Section>
         <Stack direction="column" size="sm" className="w-full">
-          <SnippetBlock
-            id="embed-iframe-snippet"
-            label="Iframe embed"
-            value={iframeSnippet}
-            copied={clipboard.copied && copiedSnippet === "iframe"}
-            onCopy={() => copySnippet("iframe", iframeSnippet)}
-          />
+          <SnippetBlock id="embed-iframe-snippet" label="Iframe embed" value={iframeSnippet} />
 
-          <SnippetBlock
-            id="embed-script-snippet"
-            label="Script embed"
-            value={scriptSnippet}
-            copied={clipboard.copied && copiedSnippet === "script"}
-            onCopy={() => copySnippet("script", scriptSnippet)}
-          />
+          <SnippetBlock id="embed-script-snippet" label="Script embed" value={scriptSnippet} />
 
           <SnippetBlock
             id="sdk-server-snippet"
             label="Server-side ad fetching"
             value={serverSnippet}
-            copied={clipboard.copied && copiedSnippet === "server"}
-            onCopy={() => copySnippet("server", serverSnippet)}
           />
 
           <SnippetBlock
             id="react-tracking-snippet"
             label="React fetching and tracking"
             value={reactSnippet}
-            copied={clipboard.copied && copiedSnippet === "react"}
-            onCopy={() => copySnippet("react", reactSnippet)}
           />
         </Stack>
       </Card.Section>
@@ -200,11 +177,11 @@ type SnippetBlockProps = {
   id: string
   label: string
   value: string
-  copied: boolean
-  onCopy: () => void
 }
 
-const SnippetBlock = ({ id, label, value, copied, onCopy }: SnippetBlockProps) => {
+const SnippetBlock = ({ id, label, value }: SnippetBlockProps) => {
+  const clipboard = useClipboard({ timeout: 2000 })
+
   return (
     <Stack direction="column" size="sm" className="w-full">
       <Label htmlFor={id}>{label}</Label>
@@ -221,12 +198,11 @@ const SnippetBlock = ({ id, label, value, copied, onCopy }: SnippetBlockProps) =
         <Button
           size="sm"
           variant="secondary"
-          prefix={copied ? <CheckIcon className="text-green-500" /> : <CopyIcon />}
-          onClick={onCopy}
-          disabled={!value}
+          prefix={clipboard.copied ? <CheckIcon className="text-green-500" /> : <CopyIcon />}
+          onClick={() => clipboard.copy(value)}
           className="absolute top-2 right-2"
         >
-          {copied ? "Copied" : "Copy"}
+          {clipboard.copied ? "Copied" : "Copy"}
         </Button>
       </div>
     </Stack>

--- a/apps/app/src/components/fields/field-form.tsx
+++ b/apps/app/src/components/fields/field-form.tsx
@@ -122,7 +122,17 @@ export const FieldForm = ({
             <FormItem>
               <FormLabel>Type</FormLabel>
               <FormControl>
-                <Select value={field.value} onValueChange={field.onChange}>
+                <Select
+                  value={field.value}
+                  onValueChange={type => {
+                    field.onChange(type)
+                    // Clear inputs the new type hides so their stale values don't
+                    // submit. Setting "" (not resetField) makes the partial update
+                    // overwrite any previously stored value.
+                    if (NO_DEFAULT.includes(type as FieldType)) form.setValue("default", "")
+                    if (NO_PLACEHOLDER.includes(type as FieldType)) form.setValue("placeholder", "")
+                  }}
+                >
                   <SelectTrigger>
                     <SelectValue placeholder="Select a type" />
                   </SelectTrigger>
@@ -151,7 +161,7 @@ export const FieldForm = ({
                   type="number"
                   min={0}
                   placeholder="0"
-                  onChange={e => onChange?.(Number.parseInt(e.target.value, 10))}
+                  onChange={e => onChange(Number.parseInt(e.target.value, 10))}
                   {...field}
                 />
               </FormControl>

--- a/apps/app/src/components/onboarding/later-button.tsx
+++ b/apps/app/src/components/onboarding/later-button.tsx
@@ -3,19 +3,24 @@ import type { OnboardingStep } from "@openads/utils"
 import type { ComponentProps } from "react"
 import { useOnboardingProgress } from "~/hooks/use-onboarding-progress"
 
-type LaterButtonProps = ComponentProps<"button"> & {
+type LaterButtonProps = ComponentProps<typeof Button> & {
   step: OnboardingStep
-  slug?: string
+  workspaceId?: string
 }
 
-export const OnboardingLaterButton = ({ children, step, slug, ...props }: LaterButtonProps) => {
+export const OnboardingLaterButton = ({
+  children,
+  step,
+  workspaceId,
+  ...props
+}: LaterButtonProps) => {
   const { continueTo, isPending } = useOnboardingProgress()
 
   return (
     <Button
       size="sm"
       variant="ghost"
-      onClick={() => continueTo(step, slug)}
+      onClick={() => continueTo(step, workspaceId)}
       isPending={isPending}
       className="mx-auto text-xs text-muted-foreground"
       {...props}

--- a/apps/app/src/components/onboarding/next-button.tsx
+++ b/apps/app/src/components/onboarding/next-button.tsx
@@ -5,16 +5,15 @@ import { useOnboardingProgress } from "~/hooks/use-onboarding-progress"
 
 type OnboardingNextButtonProps = ComponentProps<typeof Button> & {
   step: OnboardingStep
-  slug?: string
 }
 
-export const OnboardingNextButton = ({ step, slug, ...props }: OnboardingNextButtonProps) => {
+export const OnboardingNextButton = ({ step, ...props }: OnboardingNextButtonProps) => {
   const { continueTo, isPending, isSuccess } = useOnboardingProgress()
 
   return (
     <Button
       size="lg"
-      onClick={() => continueTo(step, slug)}
+      onClick={() => continueTo(step)}
       isPending={isPending || isSuccess}
       {...props}
     />

--- a/apps/app/src/components/stats/performance-chart.tsx
+++ b/apps/app/src/components/stats/performance-chart.tsx
@@ -8,7 +8,7 @@ import { cx } from "@openads/ui/cva"
 import type { ComponentProps } from "react"
 import { Area, AreaChart, CartesianGrid, XAxis } from "recharts"
 
-export type PerformanceRow = {
+type PerformanceRow = {
   date: Date
   impressions: number
   clicks: number

--- a/apps/app/src/components/stripe/stripe-connect-buttons.tsx
+++ b/apps/app/src/components/stripe/stripe-connect-buttons.tsx
@@ -11,21 +11,17 @@ import { orpc, queryClient, type RouterOutputs } from "~/lib/orpc"
 
 type StripeConnectButtonsProps = ComponentProps<"div"> & {
   workspace: NonNullable<RouterOutputs["workspace"]["getById"]>
-  onSuccess?: () => void
 }
 
-export const StripeConnectButtons = ({
-  workspace,
-  onSuccess,
-  ...props
-}: StripeConnectButtonsProps) => {
+export const StripeConnectButtons = ({ workspace, ...props }: StripeConnectButtonsProps) => {
+  const isConnectPending = workspace.stripeConnectStatus === StripeConnectStatus.Pending
+
   const connectAccount = useMutation(
     orpc.stripe.connect.create.mutationOptions({
       onSuccess: data => {
         queryClient.invalidateQueries({
           queryKey: orpc.workspace.getById.key({ input: { id: workspace.id } }),
         })
-        onSuccess?.()
         window.location.href = data.url
       },
 
@@ -42,12 +38,11 @@ export const StripeConnectButtons = ({
         queryClient.invalidateQueries({
           queryKey: orpc.workspace.getById.key({ input: { id: workspace.id } }),
         })
-        onSuccess?.()
       },
 
       onError: error => {
         logger.error("stripe.connect.delete failed", { err: error, workspaceId: workspace.id })
-        toast.error("Failed to disconnect with Stripe")
+        toast.error("Failed to disconnect from Stripe")
       },
     }),
   )
@@ -71,12 +66,10 @@ export const StripeConnectButtons = ({
           <p
             className={cx(
               "text-sm",
-              workspace.stripeConnectStatus === StripeConnectStatus.Pending
-                ? "text-yellow-500"
-                : "text-muted-foreground",
+              isConnectPending ? "text-yellow-500" : "text-muted-foreground",
             )}
           >
-            {workspace.stripeConnectStatus === StripeConnectStatus.Pending
+            {isConnectPending
               ? "Please finish connecting Stripe before advertisers can pay you."
               : "Your Stripe account is connected. Advertisers will pay through this account."}
           </p>

--- a/apps/app/src/components/tiers/tier-form.tsx
+++ b/apps/app/src/components/tiers/tier-form.tsx
@@ -6,7 +6,6 @@ import { DialogFooter } from "@openads/ui/dialog"
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@openads/ui/form"
 import { Input } from "@openads/ui/input"
 import { Label } from "@openads/ui/label"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@openads/ui/select"
 import { Stack } from "@openads/ui/stack"
 import { Textarea } from "@openads/ui/textarea"
 import { useMutation } from "@tanstack/react-query"
@@ -18,8 +17,8 @@ import { toast } from "sonner"
 import { z } from "zod"
 import { init } from "zod-empty"
 import { FormButton } from "~/components/form-button"
-import { CurrencySelect } from "~/components/tiers/currency-select"
-import { intervalLabels, tierPriceFormSchema } from "~/components/tiers/tier-price-form"
+import { TierPriceFields } from "~/components/tiers/tier-price-fields"
+import { tierPriceFormSchema } from "~/components/tiers/tier-price-form"
 import { WeightInfoDialog } from "~/components/tiers/weight-info-dialog"
 import { useZodForm } from "~/hooks/use-zod-form"
 import { wholeToCents } from "~/lib/currency"
@@ -205,7 +204,7 @@ export const TierForm = ({
                   step="0.1"
                   min={0.1}
                   placeholder="1.0"
-                  onChange={e => onChange?.(Number.parseFloat(e.target.value))}
+                  onChange={e => onChange(Number.parseFloat(e.target.value))}
                   {...field}
                 />
               </FormControl>
@@ -225,7 +224,7 @@ export const TierForm = ({
                   type="number"
                   min={0}
                   placeholder="0"
-                  onChange={e => onChange?.(Number.parseInt(e.target.value, 10))}
+                  onChange={e => onChange(Number.parseInt(e.target.value, 10))}
                   {...field}
                 />
               </FormControl>
@@ -313,70 +312,13 @@ export const TierForm = ({
                 key={row.id}
                 className="grid grid-cols-[1fr_1fr_1fr_auto] items-end gap-2 rounded-md border p-3"
               >
-                <FormField
+                <TierPriceFields
                   control={form.control}
-                  name={`initialPrices.${index}.interval`}
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel className="text-xs">Interval</FormLabel>
-                      <FormControl>
-                        <Select value={field.value} onValueChange={field.onChange}>
-                          <SelectTrigger>
-                            <SelectValue />
-                          </SelectTrigger>
-                          <SelectContent>
-                            {Object.values(BillingInterval).map(value => (
-                              <SelectItem key={value} value={value}>
-                                {intervalLabels[value]}
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-
-                <FormField
-                  control={form.control}
-                  name={`initialPrices.${index}.amountWhole`}
-                  render={({ field: { onChange, ...field } }) => {
-                    const currency = form.watch(`initialPrices.${index}.currency`)?.toUpperCase()
-                    return (
-                      <FormItem>
-                        <FormLabel className="text-xs">
-                          Price{currency ? ` (${currency})` : ""}
-                        </FormLabel>
-                        <FormControl>
-                          <Input
-                            type="number"
-                            min={0}
-                            step={1}
-                            inputMode="numeric"
-                            placeholder="19"
-                            onChange={e => onChange?.(Number.parseInt(e.target.value, 10))}
-                            {...field}
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )
+                  names={{
+                    interval: `initialPrices.${index}.interval`,
+                    amountWhole: `initialPrices.${index}.amountWhole`,
+                    currency: `initialPrices.${index}.currency`,
                   }}
-                />
-
-                <FormField
-                  control={form.control}
-                  name={`initialPrices.${index}.currency`}
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormLabel className="text-xs">Currency</FormLabel>
-                      <FormControl>
-                        <CurrencySelect value={field.value} onValueChange={field.onChange} />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
                 />
 
                 <Button

--- a/apps/app/src/components/tiers/tier-item.tsx
+++ b/apps/app/src/components/tiers/tier-item.tsx
@@ -15,7 +15,7 @@ import type { ComponentProps } from "react"
 import { toast } from "sonner"
 import { ConfirmModal } from "~/components/modals/confirm-modal"
 import { H5 } from "~/components/ui/heading"
-import { formatInterval, formatPrice, intervalRank } from "~/lib/currency"
+import { formatInterval, formatPrice } from "~/lib/currency"
 import { orpc, queryClient, type RouterOutputs } from "~/lib/orpc"
 
 type Tier = RouterOutputs["tier"]["getAll"][number]
@@ -25,19 +25,11 @@ type TierItemProps = ComponentProps<"div"> & {
   tier: Tier
 }
 
-// Picks the smallest-interval active price as the headline for the list row.
-// `tier.prices` is already filtered to active rows by the tier.getAll query.
-const headlinePrice = (prices: Tier["prices"]): Tier["prices"][number] | undefined => {
-  if (prices.length === 0) return undefined
-  return [...prices].sort((a, b) => {
-    const rankDiff = intervalRank(a.interval) - intervalRank(b.interval)
-    if (rankDiff !== 0) return rankDiff
-    return a.amount - b.amount
-  })[0]
-}
-
 const renderPriceLine = (tier: Tier): string => {
-  const head = headlinePrice(tier.prices)
+  // Prices arrive active-only and pre-sorted (interval asc — Postgres enum order
+  // Day < Week < Month < Year — then amount asc) by tier.getAll, so the first row
+  // is the smallest-interval, cheapest headline price.
+  const head = tier.prices[0]
   if (!head) return `No active prices · weight ${tier.weight}`
   const headLabel = `${formatPrice(head.amount, head.currency)} / ${formatInterval(head)}`
   const extra = tier.prices.length - 1

--- a/apps/app/src/components/tiers/tier-price-fields.tsx
+++ b/apps/app/src/components/tiers/tier-price-fields.tsx
@@ -1,0 +1,105 @@
+import { BillingInterval } from "@openads/db/client"
+import { FormControl, FormField, FormItem, FormLabel, FormMessage } from "@openads/ui/form"
+import { Input } from "@openads/ui/input"
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@openads/ui/select"
+import { type Control, type FieldValues, type Path, useWatch } from "react-hook-form"
+import { CurrencySelect } from "~/components/tiers/currency-select"
+
+export const intervalLabels: Record<BillingInterval, string> = {
+  [BillingInterval.Day]: "Per day",
+  [BillingInterval.Week]: "Per week",
+  [BillingInterval.Month]: "Per month",
+  [BillingInterval.Year]: "Per year",
+}
+
+type TierPriceFieldsProps<T extends FieldValues> = {
+  control: Control<T>
+  // Field paths differ per form (top-level vs `initialPrices.${index}.*`),
+  // so callers map their own paths onto the shared fieldset.
+  names: {
+    interval: Path<T>
+    amountWhole: Path<T>
+    currency: Path<T>
+  }
+}
+
+/**
+ * The interval/amount/currency fieldset shared by TierPriceForm and TierForm's
+ * initial-price rows. Renders only the three FormFields — grid wrappers and
+ * add/remove buttons stay at the call sites.
+ */
+export const TierPriceFields = <T extends FieldValues>({
+  control,
+  names,
+}: TierPriceFieldsProps<T>) => {
+  const currency = useWatch({ control, name: names.currency }) as string | undefined
+  const currencyLabel = currency?.toUpperCase()
+
+  return (
+    <>
+      <FormField
+        control={control}
+        name={names.interval}
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="text-xs">Interval</FormLabel>
+            <FormControl>
+              <Select value={field.value as string} onValueChange={field.onChange}>
+                <SelectTrigger>
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {Object.values(BillingInterval).map(value => (
+                    <SelectItem key={value} value={value}>
+                      {intervalLabels[value]}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={control}
+        name={names.amountWhole}
+        render={({ field: { value, onChange, ...field } }) => (
+          <FormItem>
+            <FormLabel className="text-xs">
+              Price{currencyLabel ? ` (${currencyLabel})` : ""}
+            </FormLabel>
+            <FormControl>
+              <Input
+                type="number"
+                min={0}
+                step={1}
+                inputMode="numeric"
+                placeholder="19"
+                value={value as number}
+                onChange={e => onChange(Number.parseInt(e.target.value, 10))}
+                {...field}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+
+      <FormField
+        control={control}
+        name={names.currency}
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel className="text-xs">Currency</FormLabel>
+            <FormControl>
+              <CurrencySelect value={field.value as string} onValueChange={field.onChange} />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </>
+  )
+}

--- a/apps/app/src/components/tiers/tier-price-form.tsx
+++ b/apps/app/src/components/tiers/tier-price-form.tsx
@@ -1,15 +1,13 @@
 import { BillingInterval } from "@openads/db/client"
 import { tierPriceSchema } from "@openads/db/schema"
 import { cx } from "@openads/ui/cva"
-import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@openads/ui/form"
-import { Input } from "@openads/ui/input"
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@openads/ui/select"
+import { Form } from "@openads/ui/form"
 import { useMutation } from "@tanstack/react-query"
 import type { HTMLAttributes } from "react"
 import { toast } from "sonner"
 import { z } from "zod"
 import { FormButton } from "~/components/form-button"
-import { CurrencySelect } from "~/components/tiers/currency-select"
+import { TierPriceFields } from "~/components/tiers/tier-price-fields"
 import { useZodForm } from "~/hooks/use-zod-form"
 import { wholeToCents } from "~/lib/currency"
 import { handleMutationError } from "~/lib/handle-mutation-error"
@@ -26,13 +24,6 @@ export const tierPriceFormSchema = z.object({
 })
 
 type TierPriceFormValues = z.infer<typeof tierPriceFormSchema>
-
-export const intervalLabels: Record<BillingInterval, string> = {
-  [BillingInterval.Day]: "Per day",
-  [BillingInterval.Week]: "Per week",
-  [BillingInterval.Month]: "Per month",
-  [BillingInterval.Year]: "Per year",
-}
 
 type TierPriceFormProps = HTMLAttributes<HTMLFormElement> & {
   workspaceId: string
@@ -81,8 +72,6 @@ export const TierPriceForm = ({
     })
   }
 
-  const currencyLabel = form.watch("currency")?.toUpperCase()
-
   return (
     <Form {...form}>
       <form
@@ -91,67 +80,9 @@ export const TierPriceForm = ({
         noValidate
         {...props}
       >
-        <FormField
+        <TierPriceFields
           control={form.control}
-          name="interval"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel className="text-xs">Interval</FormLabel>
-              <FormControl>
-                <Select value={field.value} onValueChange={field.onChange}>
-                  <SelectTrigger>
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {Object.values(BillingInterval).map(value => (
-                      <SelectItem key={value} value={value}>
-                        {intervalLabels[value]}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        <FormField
-          control={form.control}
-          name="amountWhole"
-          render={({ field: { onChange, ...field } }) => (
-            <FormItem>
-              <FormLabel className="text-xs">
-                Price{currencyLabel ? ` (${currencyLabel})` : ""}
-              </FormLabel>
-              <FormControl>
-                <Input
-                  type="number"
-                  min={0}
-                  step={1}
-                  inputMode="numeric"
-                  placeholder="19"
-                  onChange={e => onChange?.(Number.parseInt(e.target.value, 10))}
-                  {...field}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
-
-        <FormField
-          control={form.control}
-          name="currency"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel className="text-xs">Currency</FormLabel>
-              <FormControl>
-                <CurrencySelect value={field.value} onValueChange={field.onChange} />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
+          names={{ interval: "interval", amountWhole: "amountWhole", currency: "currency" }}
         />
 
         <FormButton size="sm" isPending={createPrice.isPending}>

--- a/apps/app/src/components/tiers/weight-info-dialog.tsx
+++ b/apps/app/src/components/tiers/weight-info-dialog.tsx
@@ -11,6 +11,7 @@ import {
 } from "@openads/ui/dialog"
 import { Stack } from "@openads/ui/stack"
 import { InfoIcon } from "lucide-react"
+import { Fragment } from "react"
 
 // Three example tiers, chosen so the percentages land near the simple "this is what
 // weight does" intuition (Premium ~2x Standard, Promo ~half).
@@ -52,14 +53,14 @@ export const WeightInfoDialog = () => {
               Share of impressions
             </h3>
 
-            <div className="mt-4 grid grid-cols-[1fr_minmax(0,2fr)_auto] items-center gap-x-4 gap-y-3">
+            <div className="mt-4 grid grid-cols-[1fr_minmax(0,2fr)_auto] items-center gap-x-4 gap-y-3 text-sm">
               {exampleTiers.map(tier => {
                 const share = tier.weight / totalWeight
                 const widthPct = `${(share * 100).toFixed(1)}%`
                 const sharePct = `${Math.round(share * 100)}%`
 
                 return (
-                  <Stack key={tier.name} direction="row" size="sm" className="contents text-sm">
+                  <Fragment key={tier.name}>
                     <div className="flex items-baseline gap-2">
                       <span className="font-medium">{tier.name}</span>
                       <span className="font-mono text-muted-foreground text-xs tabular-nums">
@@ -77,7 +78,7 @@ export const WeightInfoDialog = () => {
                     <span className="font-mono text-muted-foreground text-xs tabular-nums">
                       {sharePct}
                     </span>
-                  </Stack>
+                  </Fragment>
                 )
               })}
             </div>

--- a/apps/app/src/components/workspaces/create-workspace-form.tsx
+++ b/apps/app/src/components/workspaces/create-workspace-form.tsx
@@ -27,11 +27,7 @@ export const CreateWorkspaceForm = ({
   onSuccess,
   ...props
 }: CreateWorkspaceFormProps) => {
-  const form = useZodForm(workspaceSchema, {
-    defaultValues: {
-      ...init(workspaceSchema),
-    },
-  })
+  const form = useZodForm(workspaceSchema, { defaultValues: init(workspaceSchema) })
 
   const onSuccessHandler = async (data: RouterOutputs["workspace"]["create"]) => {
     toast.success("Workspace created successfully")

--- a/apps/app/src/hooks/use-onboarding-progress.ts
+++ b/apps/app/src/hooks/use-onboarding-progress.ts
@@ -19,16 +19,16 @@ export const useOnboardingProgress = () => {
     }),
   )
 
-  const continueTo = async (step: OnboardingStep, id?: string) => {
+  const continueTo = async (step: OnboardingStep, workspaceId?: string) => {
     // Persist progress before navigation so refreshes resume from the next step.
     await mutateAsync({ step })
 
     if (step === "completed") {
       // A completed onboarding run should land in the created workspace when possible.
-      if (id) {
+      if (workspaceId) {
         return navigate({
           to: "/$workspaceId",
-          params: { workspaceId: id },
+          params: { workspaceId },
           search: { onboarded: true },
         })
       }
@@ -40,7 +40,7 @@ export const useOnboardingProgress = () => {
     return navigate({
       to: "/onboarding/$step",
       params: { step },
-      search: { workspaceId: preWorkspaceSteps.includes(step) ? undefined : id },
+      search: { workspaceId: preWorkspaceSteps.includes(step) ? undefined : workspaceId },
     })
   }
 

--- a/apps/app/src/lib/currency.ts
+++ b/apps/app/src/lib/currency.ts
@@ -3,9 +3,6 @@ import type { BillingInterval } from "@openads/db/client"
 /** Convert a whole-unit integer (e.g. `19` for $19) to cents (`1900`). */
 export const wholeToCents = (whole: number): number => Math.round(whole * 100)
 
-/** Convert cents (e.g. `1900`) to whole units (`19`). Truncates fractional cents. */
-export const centsToWhole = (cents: number): number => Math.floor(cents / 100)
-
 /** Format cents as a localized currency string. */
 export const formatPrice = (cents: number, currency: string): string =>
   new Intl.NumberFormat("en-US", {
@@ -42,18 +39,4 @@ export const formatTierPrice = (price: {
   return price.intervalCount === 1
     ? `${amount} / ${intervalLabel}`
     : `${amount} every ${intervalLabel}`
-}
-
-/** Ordinal weight for interval sorting (Day < Week < Month < Year). */
-export const intervalRank = (interval: BillingInterval): number => {
-  switch (interval) {
-    case "Day":
-      return 0
-    case "Week":
-      return 1
-    case "Month":
-      return 2
-    case "Year":
-      return 3
-  }
 }

--- a/apps/app/src/routes/_layout.onboarding.$step.tsx
+++ b/apps/app/src/routes/_layout.onboarding.$step.tsx
@@ -84,7 +84,7 @@ function OnboardingStepPage() {
               <div className="space-y-4">
                 <StripeConnectButtons workspace={data} />
 
-                <OnboardingLaterButton step="completed" id={workspaceId}>
+                <OnboardingLaterButton step="completed" workspaceId={workspaceId}>
                   I'll connect Stripe later
                 </OnboardingLaterButton>
               </div>


### PR DESCRIPTION
Part of a whole-codebase DHH-style review run via multi-agent workflow: 89 findings survived adversarial verification, applied across 8 themed PRs. Every finding below was checked against the actual code before being fixed.

## Findings addressed

- `apps/app/src/components/tiers/tier-item.tsx:30` — **headline-price-resorts-presorted-data**: Why re-sort what the database already sorted? tier.getAll includes prices with orderBy: [{ interval: "asc" }, { amount: "asc" }], and the Postgres enum declares Day/Week/Month/Year in exactly intervalRank's order — so headlinePrice is a spread, a sort, and a helper function to compute tier.prices[0].
- `apps/app/src/components/fields/field-form.tsx:163` — **hidden-fields-submit-stale-values**: Real bug: type "discount code" into Default, switch the field type to Switch, submit — the Default input disappears from the UI but RHF keeps the value registered (shouldUnregister defaults to false), so the stale "discount code" silently submits. Same for Placeholder on Image/Switch.
- `apps/app/src/components/ads/image-upload.tsx:38` — **hand-rolled-uploading-state-around-mutation**: Half the upload flow lives in a mutation and the other half in a hand-rolled isUploading/try/catch/finally with a manual toast. One useMutation whose mutationFn does presign + PUT gives you isPending, onError, and onSuccess for free — the useState, the try/finally, and the catch all evaporate.
- `apps/app/src/components/tiers/tier-form.tsx:311` — **price-row-fields-duplicated-across-forms**: This interval/amount/currency row (lines 311–392) is a near character-for-character copy of TierPriceForm's three FormFields — same grid, same labels, same parseInt onChange, same currency-suffix trick. Two copies of one fieldset is exactly the kind of duplication that should boil down to one place.
- `apps/app/src/components/tiers/tier-form.tsx:208` — **optional-chaining-on-rhf-onchange**: When would onChange ever be undefined? It's destructured straight off the RHF controller field — the `?.` is defensive design against an impossible state. Same noise at lines 228 and 358 here, field-form.tsx:154, and tier-price-form.tsx:134.
- `apps/app/src/components/tiers/weight-info-dialog.tsx:62` — **stack-with-display-contents-is-a-fragment**: A Stack whose layout is immediately nuked by className="contents" isn't a Stack — it's a DOM node rendered purely to carry a key. A bit much when a keyed Fragment does the same with zero markup.
- **[high]** `apps/app/src/components/onboarding/later-button.tsx:8` — **slug-prop-swallows-workspace-id**: Prop is named `slug` but the value is a workspace id — and the only caller (routes/_layout.onboarding.$step.tsx:87) passes `id={workspaceId}`, which typechecks as an HTML attribute and spreads onto the DOM while `slug` stays undefined. So "I'll connect Stripe later" calls `continueTo("completed", undefined)` and falls back to navigating "/" — the user never lands in their new workspace with `onboarded: true`. Names must stand alone; this one lied and shipped a bug.
- `apps/app/src/components/onboarding/next-button.tsx:8` — **dead-slug-prop-on-next-button**: `slug?: string` is never passed by the sole caller (the welcome step). YAGNI — a prop nobody uses is just a trap for the next reader.
- `apps/app/src/components/embed/embed-snippet.tsx:31` — **lifted-copy-state-with-string-id-bookkeeping**: Parent shares one `useClipboard` across four blocks and bolts on a `copiedSnippet` string-id useState to tell them apart, threading `copied`/`onCopy` through props. That's state bookkeeping the child should own — and the ids ("iframe") don't even match the htmlFor ids ("embed-iframe-snippet").
- `apps/app/src/components/embed/embed-snippet.tsx:33` — **dead-fallback-for-required-env**: `env.VITE_BASE_URL || (typeof window !== "undefined" ? window.location.origin : "")` — VITE_BASE_URL is a required `z.string()` in env.ts, so the fallback can never run, and there's no SSR in apps/app so the `typeof window` dance is doubly defensive. When would this ever be undefined?
- `apps/app/src/components/embed/embed-snippet.tsx:226` — **disabled-check-for-impossible-empty-value**: `disabled={!value}` on the copy button — `value` is always a non-empty template literal built two screens up. Defensive design for a state that can't exist.
- `apps/app/src/components/stripe/stripe-connect-buttons.tsx:14` — **onsuccess-callback-nobody-passes**: `onSuccess?: () => void` is invoked in both mutation handlers but the component's only caller (the onboarding route) never passes it. Optional props "for flexibility" are YAGNI.
- `apps/app/src/components/stripe/stripe-connect-buttons.tsx:74` — **pending-ternary-computed-twice**: `workspace.stripeConnectStatus === StripeConnectStatus.Pending` evaluated twice in adjacent ternaries — same condition driving class and copy. Boil it down to one name. (And while there: "Failed to disconnect with Stripe" → "from Stripe".)
- `apps/app/src/components/stats/performance-chart.tsx:11` — **exported-type-imported-nowhere**: `export type PerformanceRow` — nobody imports it; both callers pass rows typed straight off RouterOutputs and rely on structural compatibility. Narrow the public API.
- `apps/app/src/components/workspaces/create-workspace-form.tsx:31` — **pointless-spread-of-init-result**: `defaultValues: { ...init(workspaceSchema) }` — spreading a fresh object into another fresh object is noise.

## Verification

bun run lint (oxlint, 0 warnings/errors), bun run check-types (17/17 turbo tasks pass, @openads/app re-checked clean), bun test (22 pass, 0 fail) — all run after edits and re-run on the final committed state. Tree clean on dhh/app-component-cleanups; not pushed.

## Notes

All 15 findings applied. The two conflicting onboarding refinedFixes (rename slug->workspaceId in next-button vs delete it) were reconciled per the group note's intent: later-button's prop renamed to workspaceId (fixing the shipped bug where id={workspaceId} spread onto the DOM and 'I'll connect Stripe later' navigated to / instead of the new workspace), next-button's never-passed slug prop deleted outright, and continueTo's second param renamed to workspaceId — no `slug` prop survives anywhere. The shipped onboarding bug got a fix: commit as instructed. TierPriceFields was extracted as the verifier specified (generic over FieldValues with a names map of Path<T>; intervalLabels moved into the new file); three localized `as` casts on field values were needed because PathValue stays deferred for generic paths — RHF's typing limit, not a behavior change. Field-form now clears default/placeholder to "" (not resetField) on type change so partial updates overwrite stale DB values. The stripe-connect commit also fixes user-facing copy: 'Failed to disconnect with Stripe' -> 'from Stripe'.
