### PR TITLE
refactor(orpc): server-side dedup, tenant scoping, and rate-limit hardening

### DIFF
--- a/apps/app/src/components/ads/serving-state.tsx
+++ b/apps/app/src/components/ads/serving-state.tsx
@@ -1,4 +1,5 @@
 import type { AdStatus, SubscriptionStatus } from "@openads/db/client"
+import { isServingSubscription } from "@openads/db/lib/subscription"
 import { cx } from "@openads/ui/cva"
 import type { ComponentProps } from "react"
 
@@ -9,14 +10,12 @@ type ServingInput = {
 
 export type ServingState = ReturnType<typeof getServingState>
 
-export const isPaid = (status: SubscriptionStatus) => status === "Active" || status === "Trialing"
-
 /**
  * An ad serves only when the creative is approved AND the subscription is
  * paid up — surface that two-flag rule as a single, glanceable state.
  */
 export const getServingState = (ad: ServingInput) => {
-  const paid = isPaid(ad.subscription.status)
+  const paid = isServingSubscription(ad.subscription.status)
 
   if (ad.status === "Approved" && paid) {
     return {

--- a/apps/app/src/routes/$workspaceId/account/-components/profile-form.tsx
+++ b/apps/app/src/routes/$workspaceId/account/-components/profile-form.tsx
@@ -96,7 +96,6 @@ export const AccountProfileForm = ({ user, ...props }: AccountProfileFormProps) 
             file: avatar.previewUrl,
             fileName: avatar.file.name,
             contentType: avatar.file.type,
-            cacheControl: "public, max-age=31536000",
           })
 
           imagePayload = uploadResult.url

--- a/apps/app/src/routes/$workspaceId/ads/$adId.tsx
+++ b/apps/app/src/routes/$workspaceId/ads/$adId.tsx
@@ -1,4 +1,5 @@
 import { formatDate, getInitials, isValidUrl } from "@dirstack/utils"
+import { isServingSubscription } from "@openads/db/lib/subscription"
 import { Avatar, AvatarFallback, AvatarImage } from "@openads/ui/avatar"
 import { Badge } from "@openads/ui/badge"
 import { Button } from "@openads/ui/button"
@@ -9,7 +10,7 @@ import { ArrowUpRightIcon, CheckIcon, MessageSquareIcon, XIcon } from "lucide-re
 import { type ReactNode, useState } from "react"
 import { toast } from "sonner"
 import { AdStats } from "~/components/ads/ad-stats"
-import { getServingState, isPaid, ServingDot } from "~/components/ads/serving-state"
+import { getServingState, ServingDot } from "~/components/ads/serving-state"
 import { AdStatusBadge, SubscriptionStatusBadge } from "~/components/ads/status-badge"
 import { Card } from "~/components/ui/card"
 import { Header, HeaderActions, HeaderTitle } from "~/components/ui/header"
@@ -153,12 +154,13 @@ function AdReviewPage() {
                   <span className="flex flex-wrap items-center gap-2 tabular-nums">
                     {formatTierPrice(tierPrice)}
                     <SubscriptionStatusBadge status={subscription.status} />
-                    {subscription.currentPeriodEnd && isPaid(subscription.status) && (
-                      <span className="text-muted-foreground">
-                        {subscription.cancelAtPeriodEnd ? "ends" : "renews"}{" "}
-                        {formatDate(subscription.currentPeriodEnd, "medium", "en-US")}
-                      </span>
-                    )}
+                    {subscription.currentPeriodEnd &&
+                      isServingSubscription(subscription.status) && (
+                        <span className="text-muted-foreground">
+                          {subscription.cancelAtPeriodEnd ? "ends" : "renews"}{" "}
+                          {formatDate(subscription.currentPeriodEnd, "medium", "en-US")}
+                        </span>
+                      )}
                   </span>
                 </DetailRow>
 

--- a/apps/app/src/routes/$workspaceId/advertisers/$advertiserId.tsx
+++ b/apps/app/src/routes/$workspaceId/advertisers/$advertiserId.tsx
@@ -1,5 +1,5 @@
 import { formatDate, formatNumber, getInitials, isValidUrl } from "@dirstack/utils"
-import type { BillingInterval } from "@openads/db/client"
+import { isServingSubscription } from "@openads/db/lib/subscription"
 import { Avatar, AvatarFallback, AvatarImage } from "@openads/ui/avatar"
 import { Badge } from "@openads/ui/badge"
 import { Button } from "@openads/ui/button"
@@ -9,7 +9,7 @@ import { createFileRoute, Link } from "@tanstack/react-router"
 import { ArrowUpRightIcon, MailIcon } from "lucide-react"
 import type { ComponentProps } from "react"
 import { AdAvatar } from "~/components/ads/ad-avatar"
-import { getServingState, isPaid } from "~/components/ads/serving-state"
+import { getServingState } from "~/components/ads/serving-state"
 import { AdStatusBadge, SubscriptionStatusBadge } from "~/components/ads/status-badge"
 import { QueryCell } from "~/components/query-cell"
 import { formatCtr, Metric } from "~/components/stats/metric"
@@ -32,29 +32,6 @@ export const Route = createFileRoute("/$workspaceId/advertisers/$advertiserId")(
 type Advertiser = RouterOutputs["advertiser"]["getById"]
 type AdvertiserAd = Advertiser["ads"][number]
 
-const MONTHS_PER_INTERVAL: Record<BillingInterval, number> = {
-  Day: 1 / 30,
-  Week: 7 / 30,
-  Month: 1,
-  Year: 12,
-}
-
-/**
- * Normalize the advertiser's paid subscriptions to a monthly figure — the
- * number a publisher actually thinks in. Assumes one currency per workspace.
- */
-const getMonthlyRevenue = (ads: AdvertiserAd[]) => {
-  const paid = ads.filter(ad => isPaid(ad.subscription.status))
-  if (paid.length === 0) return null
-
-  const cents = paid.reduce((total, { subscription: { tierPrice } }) => {
-    const months = MONTHS_PER_INTERVAL[tierPrice.interval] * tierPrice.intervalCount
-    return total + tierPrice.amount / months
-  }, 0)
-
-  return formatPrice(Math.round(cents), paid[0]!.subscription.tierPrice.currency)
-}
-
 function AdvertiserDetailPage() {
   const { workspaceId, advertiserId } = Route.useParams()
   const initial = Route.useLoaderData()
@@ -76,7 +53,8 @@ function AdvertiserDetailPage() {
       )}
       success={({ data: advertiser }) => {
         const { totals } = advertiser
-        const monthlyRevenue = getMonthlyRevenue(advertiser.ads)
+        const monthlyRevenue =
+          totals.activeSubscriptions > 0 ? formatPrice(totals.monthlyCents, totals.currency) : null
 
         return (
           <>
@@ -171,7 +149,7 @@ type AdvertiserAdRowProps = ComponentProps<"div"> & {
 const AdvertiserAdRow = ({ workspaceId, ad, className, ...props }: AdvertiserAdRowProps) => {
   const { subscription } = ad
   const serving = getServingState(ad)
-  const paid = isPaid(subscription.status)
+  const paid = isServingSubscription(subscription.status)
 
   return (
     <div

--- a/packages/db/src/lib/subscription.ts
+++ b/packages/db/src/lib/subscription.ts
@@ -1,0 +1,15 @@
+import { SubscriptionStatus } from "../generated/prisma/browser"
+
+/**
+ * Subscription statuses that count as "paid up" for serving and revenue: an ad
+ * serves only when its creative is Approved AND its subscription is in one of
+ * these states. Deliberately typed as a mutable array — Prisma `in:` filters
+ * reject readonly tuples.
+ */
+export const SERVING_SUBSCRIPTION_STATUSES: SubscriptionStatus[] = [
+  SubscriptionStatus.Active,
+  SubscriptionStatus.Trialing,
+]
+
+export const isServingSubscription = (status: SubscriptionStatus) =>
+  SERVING_SUBSCRIPTION_STATUSES.includes(status)

--- a/packages/orpc/src/index.ts
+++ b/packages/orpc/src/index.ts
@@ -1,5 +1,6 @@
 import type { Session } from "@openads/auth/server"
 import { Prisma, type db } from "@openads/db"
+import type { Workspace } from "@openads/db/client"
 import type { EmailClient } from "@openads/emails"
 import type { Logger } from "@openads/logger"
 import type { RedisClient } from "@openads/redis"
@@ -103,7 +104,16 @@ export const authProcedure = publicProcedure.use(({ context, next }) => {
   return next({ context: { user: context.auth.user } })
 })
 
-const findMemberWorkspace = async (context: Context & { user: AuthUser }, workspaceId: string) => {
+/**
+ * Resolves a workspace the user is a member of, or throws FORBIDDEN. Exported
+ * for the rare handlers that can't use `workspaceMw` because the workspace id
+ * doesn't come from procedure input (e.g. the Stripe OAuth callback reads it
+ * from Redis state).
+ */
+export const findMemberWorkspace = async (
+  context: Context & { user: AuthUser },
+  workspaceId: string,
+) => {
   const workspace = await context.db.workspace.findFirst({
     where: { AND: [{ id: workspaceId }, context.db.workspace.belongsTo(context.user.id)] },
   })
@@ -133,8 +143,6 @@ export const workspaceMw = os
 
     return next({ context: { workspace } })
   })
-
-type Workspace = NonNullable<Awaited<ReturnType<typeof db.workspace.findFirst>>>
 
 /**
  * Layered on top of `workspaceMw`: assumes `workspace` is in context, refuses

--- a/packages/orpc/src/lib/ad-serving.ts
+++ b/packages/orpc/src/lib/ad-serving.ts
@@ -1,6 +1,8 @@
 import type { db } from "@openads/db"
 import { FieldType } from "@openads/db/client"
+import { SERVING_SUBSCRIPTION_STATUSES } from "@openads/db/lib/subscription"
 import { z } from "zod"
+import { startOfUtcDay } from "./date"
 
 // Single source of truth for the ad-serving shape. The SDK `/v1` endpoint
 // `.output()`, the embed serving shape, and the runtime types all derive from
@@ -67,7 +69,7 @@ const fetchEligibleAds = async ({
       ...(excludeIds.length > 0 ? { id: { notIn: excludeIds } } : {}),
       subscription: {
         workspaceId,
-        status: { in: ["Active", "Trialing"] },
+        status: { in: SERVING_SUBSCRIPTION_STATUSES },
         // Weight is sourced live from the tier — applying the floor here
         // means tier weight edits affect placement targeting immediately.
         ...(weightGte !== undefined ? { tier: { weight: { gte: weightGte } } } : {}),
@@ -121,9 +123,7 @@ const fetchImpressionsByAd = async ({
   adIds: Array<string>
   fairnessWindowDays: number
 }): Promise<Map<string, number>> => {
-  const since = new Date()
-  since.setUTCHours(0, 0, 0, 0)
-  since.setUTCDate(since.getUTCDate() - Math.max(0, fairnessWindowDays - 1))
+  const since = startOfUtcDay(fairnessWindowDays - 1)
 
   const stats = await db.adStat.groupBy({
     by: ["adId"],
@@ -184,26 +184,8 @@ const pickWeightedAd = (
  * e.g. ask for `weight >= 2.5` for premium banner positions, anything for
  * regular cards. OpenAds doesn't carry a placement concept itself.
  */
-export const findServingAd = async ({
-  db,
-  workspaceId,
-  weightGte,
-  excludeIds = [],
-  leastServedBoostMax = 1.2,
-  fairnessWindowDays = 1,
-}: FindServingAdProps): Promise<ServingAd | null> => {
-  const ads = await fetchEligibleAds({ db, workspaceId, weightGte, excludeIds })
-
-  if (ads.length === 0) return null
-  if (ads.length === 1) return ads[0] ?? null
-
-  const impressionsByAd = await fetchImpressionsByAd({
-    db,
-    adIds: ads.map(ad => ad.id),
-    fairnessWindowDays,
-  })
-
-  return pickWeightedAd(ads, impressionsByAd, leastServedBoostMax)
+export const findServingAd = async (props: FindServingAdProps): Promise<ServingAd | null> => {
+  return (await findServingAds({ ...props, count: 1 }))[0] ?? null
 }
 
 /**

--- a/packages/orpc/src/lib/ad-tracking.ts
+++ b/packages/orpc/src/lib/ad-tracking.ts
@@ -1,5 +1,6 @@
 import type { db } from "@openads/db"
 import type { RedisClient } from "@openads/redis"
+import { startOfUtcDay } from "./date"
 
 const TRACKING_WINDOW_SECONDS = 60
 const IMPRESSION_LIMIT_PER_MINUTE = 30
@@ -14,12 +15,6 @@ type RecordAdEventProps = {
 
 type RecordAdEventResult = {
   success: boolean
-}
-
-const getTodayBucket = (): Date => {
-  const today = new Date()
-  today.setUTCHours(0, 0, 0, 0)
-  return today
 }
 
 const isRateLimited = async ({
@@ -49,13 +44,17 @@ const recordAdEvent = async (
   event: "impression" | "click",
   limit: number,
 ): Promise<RecordAdEventResult> => {
-  const ad = await db.ad.findUnique({ where: { id: adId }, select: { id: true } })
-  if (!ad) return { success: false }
-
+  // The cheap Redis gate runs first so a flood never costs a Postgres read
+  // per request. The existence check stays before the upsert — with
+  // relationMode="prisma" there are no DB-level FKs to stop orphan AdStat
+  // rows for fabricated adIds.
   const limited = await isRateLimited({ redis, clientIp, adId, event, limit })
   if (limited) return { success: false }
 
-  const date = getTodayBucket()
+  const ad = await db.ad.findUnique({ where: { id: adId }, select: { id: true } })
+  if (!ad) return { success: false }
+
+  const date = startOfUtcDay()
   await db.adStat.upsert({
     where: { adId_date: { adId, date } },
     create: {

--- a/packages/orpc/src/lib/date.ts
+++ b/packages/orpc/src/lib/date.ts
@@ -1,0 +1,12 @@
+/**
+ * UTC midnight `daysAgo` days back. `AdStat.date` rows are bucketed at UTC
+ * midnight on the write path, so every read window must derive its inclusive
+ * lower bound from this same function — a drifted copy (local-time midnight,
+ * an off-by-one) would silently disagree with the recorded buckets.
+ */
+export const startOfUtcDay = (daysAgo = 0): Date => {
+  const date = new Date()
+  date.setUTCHours(0, 0, 0, 0)
+  date.setUTCDate(date.getUTCDate() - Math.max(0, daysAgo))
+  return date
+}

--- a/packages/orpc/src/lib/revenue.ts
+++ b/packages/orpc/src/lib/revenue.ts
@@ -1,0 +1,25 @@
+import type { BillingInterval, TierPrice } from "@openads/db/client"
+
+const MONTHS_PER_INTERVAL: Record<BillingInterval, number> = {
+  Day: 1 / 30,
+  Week: 7 / 30,
+  Month: 1,
+  Year: 12,
+}
+
+/**
+ * Normalizes recurring subscription prices to a single monthly figure in
+ * cents — the number a publisher actually thinks in. Pass only the
+ * subscriptions that should count toward revenue (callers filter by
+ * serving status). Assumes one currency per workspace.
+ */
+export const sumMonthlyCents = (
+  subscriptions: Array<{ tierPrice: Pick<TierPrice, "interval" | "intervalCount" | "amount"> }>,
+) => {
+  const cents = subscriptions.reduce((total, { tierPrice }) => {
+    const months = MONTHS_PER_INTERVAL[tierPrice.interval] * tierPrice.intervalCount
+    return total + tierPrice.amount / months
+  }, 0)
+
+  return Math.round(cents)
+}

--- a/packages/orpc/src/routers/ad.ts
+++ b/packages/orpc/src/routers/ad.ts
@@ -12,6 +12,7 @@ import { z } from "zod"
 import { adMw, authProcedure, type Context, publicProcedure, workspaceMw } from "../index"
 import { findServingAds, servingAdSchema } from "../lib/ad-serving"
 import { recordAdClick, recordAdImpression } from "../lib/ad-tracking"
+import { startOfUtcDay } from "../lib/date"
 
 const createFromCheckoutInput = z.object({
   workspaceId: z.string().min(1),
@@ -45,7 +46,7 @@ const getConnectedCheckoutSession = async ({
 }: Pick<Context, "db" | "stripe"> & { workspaceId: string; sessionId: string }) => {
   const workspace = await db.workspace.findUnique({
     where: { id: workspaceId },
-    select: { id: true, stripeConnectId: true },
+    select: { id: true, name: true, slug: true, faviconUrl: true, stripeConnectId: true },
   })
 
   if (!workspace?.stripeConnectId) {
@@ -64,7 +65,7 @@ const getConnectedCheckoutSession = async ({
     throw new ORPCError("BAD_REQUEST", { message: "Checkout workspace mismatch." })
   }
 
-  return { session, connectedAccountId: workspace.stripeConnectId }
+  return { session, workspace, connectedAccountId: workspace.stripeConnectId }
 }
 
 // ---- SDK-facing public procedures (re-exported via `publicRouter`) ----
@@ -156,7 +157,7 @@ export const recordClick = publicProcedure
 const getCheckoutInfo = publicProcedure
   .input(checkoutSessionInput)
   .handler(async ({ context: { db, stripe }, input: { workspaceId, sessionId } }) => {
-    const { session } = await getConnectedCheckoutSession({
+    const { session, workspace } = await getConnectedCheckoutSession({
       db,
       stripe,
       workspaceId,
@@ -176,13 +177,11 @@ const getCheckoutInfo = publicProcedure
       throw new ORPCError("BAD_REQUEST", { message: "Missing checkout metadata." })
     }
 
-    const [workspace, tierPrice, fields, existingAd] = await Promise.all([
-      db.workspace.findUnique({
-        where: { id: workspaceId },
-        select: { id: true, name: true, slug: true, faviconUrl: true },
-      }),
-      db.tierPrice.findUnique({
-        where: { id: tierPriceId },
+    const [tierPrice, fields, existingAd] = await Promise.all([
+      // Scoped to the workspace — session metadata is publisher-controlled,
+      // so an unscoped lookup would let it point at another tenant's price.
+      db.tierPrice.findFirst({
+        where: { id: tierPriceId, tier: { workspaceId } },
         select: {
           id: true,
           interval: true,
@@ -205,12 +204,19 @@ const getCheckoutInfo = publicProcedure
       })(),
     ])
 
-    if (!workspace || !tierPrice) {
+    if (!tierPrice) {
       throw new ORPCError("NOT_FOUND")
     }
 
     return {
-      workspace,
+      // Picked shape — this is an unauthenticated procedure, so the helper's
+      // `stripeConnectId` must not leak into the response.
+      workspace: {
+        id: workspace.id,
+        name: workspace.name,
+        slug: workspace.slug,
+        faviconUrl: workspace.faviconUrl,
+      },
       tier: tierPrice.tier,
       tierPrice,
       fields,
@@ -229,7 +235,7 @@ const createFromCheckout = publicProcedure
       context: { db, emails, logger, s3, stripe, env },
       input: { workspaceId, sessionId, name, websiteUrl, meta },
     }) => {
-      const { connectedAccountId, session } = await getConnectedCheckoutSession({
+      const { connectedAccountId, session, workspace } = await getConnectedCheckoutSession({
         db,
         stripe,
         workspaceId,
@@ -385,12 +391,7 @@ const createFromCheckout = publicProcedure
         include: { user: { select: { email: true, name: true } } },
       })
 
-      const workspace = await db.workspace.findUnique({
-        where: { id: workspaceId },
-        select: { id: true, name: true },
-      })
-
-      if (workspace && reviewers.length > 0) {
+      if (reviewers.length > 0) {
         const { html, text } = await renderAdPendingReview({
           workspaceName: workspace.name,
           advertiserName: advertiser.name,
@@ -453,9 +454,7 @@ export const adRouter = {
     .input(adIdentitySchema.extend({ days: z.number().int().min(1).max(180).default(30) }))
     .use(adMw)
     .handler(async ({ context: { ad, db }, input: { days } }) => {
-      const since = new Date()
-      since.setUTCHours(0, 0, 0, 0)
-      since.setUTCDate(since.getUTCDate() - (days - 1))
+      const since = startOfUtcDay(days - 1)
 
       const rows = await db.adStat.findMany({
         where: { adId: ad.id, date: { gte: since } },

--- a/packages/orpc/src/routers/advertiser.ts
+++ b/packages/orpc/src/routers/advertiser.ts
@@ -1,11 +1,10 @@
-import { AdStatus, SubscriptionStatus } from "@openads/db/client"
+import { AdStatus } from "@openads/db/client"
+import { isServingSubscription, SERVING_SUBSCRIPTION_STATUSES } from "@openads/db/lib/subscription"
 import { ORPCError } from "@orpc/server"
 import { z } from "zod"
 import { authProcedure, workspaceMw } from "../index"
-
-const isActiveSubscriptionStatus = (status: SubscriptionStatus) => {
-  return status === SubscriptionStatus.Active || status === SubscriptionStatus.Trialing
-}
+import { startOfUtcDay } from "../lib/date"
+import { sumMonthlyCents } from "../lib/revenue"
 
 export const advertiserRouter = {
   getAll: authProcedure
@@ -17,23 +16,22 @@ export const advertiserRouter = {
     )
     .use(workspaceMw)
     .handler(async ({ context: { db, workspace }, input: { query } }) => {
-      const search = query?.trim()
       const subscriptionFilter = { workspaceId: workspace.id, ad: { isNot: null } }
 
       const advertisers = await db.advertiser.findMany({
         where: {
           workspaceId: workspace.id,
           subscriptions: { some: subscriptionFilter },
-          ...(search
+          ...(query
             ? {
                 OR: [
-                  { name: { contains: search, mode: "insensitive" } },
-                  { email: { contains: search, mode: "insensitive" } },
+                  { name: { contains: query, mode: "insensitive" } },
+                  { email: { contains: query, mode: "insensitive" } },
                   {
                     subscriptions: {
                       some: {
                         workspaceId: workspace.id,
-                        ad: { is: { name: { contains: search, mode: "insensitive" } } },
+                        ad: { is: { name: { contains: query, mode: "insensitive" } } },
                       },
                     },
                   },
@@ -59,7 +57,6 @@ export const advertiserRouter = {
       })
 
       const advertiserIds = advertisers.map(advertiser => advertiser.id)
-      const activeStatuses = [SubscriptionStatus.Active, SubscriptionStatus.Trialing]
 
       const [activeSubscriptionCounts, activeAdCounts] = advertiserIds.length
         ? await Promise.all([
@@ -68,7 +65,7 @@ export const advertiserRouter = {
               where: {
                 ...subscriptionFilter,
                 advertiserId: { in: advertiserIds },
-                status: { in: activeStatuses },
+                status: { in: SERVING_SUBSCRIPTION_STATUSES },
               },
               _count: true,
             }),
@@ -77,7 +74,7 @@ export const advertiserRouter = {
               where: {
                 workspaceId: workspace.id,
                 advertiserId: { in: advertiserIds },
-                status: { in: activeStatuses },
+                status: { in: SERVING_SUBSCRIPTION_STATUSES },
                 ad: { is: { status: AdStatus.Approved } },
               },
               _count: true,
@@ -134,9 +131,7 @@ export const advertiserRouter = {
     )
     .use(workspaceMw)
     .handler(async ({ context: { db, workspace }, input: { advertiserId } }) => {
-      const since = new Date()
-      since.setUTCHours(0, 0, 0, 0)
-      since.setUTCDate(since.getUTCDate() - 29)
+      const since = startOfUtcDay(29)
 
       const advertiser = await db.advertiser.findFirst({
         where: {
@@ -170,7 +165,7 @@ export const advertiserRouter = {
               tier: true,
               tierPrice: true,
             },
-            orderBy: { createdAt: "desc" },
+            orderBy: [{ ad: { updatedAt: "desc" } }, { createdAt: "desc" }],
           },
         },
       })
@@ -179,63 +174,61 @@ export const advertiserRouter = {
         throw new ORPCError("NOT_FOUND")
       }
 
-      const ads = advertiser.subscriptions
-        .flatMap(subscription => {
-          const ad = subscription.ad
-          if (!ad) return []
+      const ads = advertiser.subscriptions.flatMap(subscription => {
+        const ad = subscription.ad
+        if (!ad) return []
 
-          const stats = ad.stats.reduce(
-            (total, row) => {
-              return {
-                impressions: total.impressions + row.impressions,
-                clicks: total.clicks + row.clicks,
-              }
-            },
-            { impressions: 0, clicks: 0 },
-          )
+        const stats = ad.stats.reduce(
+          (total, row) => {
+            return {
+              impressions: total.impressions + row.impressions,
+              clicks: total.clicks + row.clicks,
+            }
+          },
+          { impressions: 0, clicks: 0 },
+        )
 
-          return [
-            {
-              id: ad.id,
-              name: ad.name,
-              status: ad.status,
-              websiteUrl: ad.websiteUrl,
-              faviconUrl: ad.faviconUrl,
-              createdAt: ad.createdAt,
-              updatedAt: ad.updatedAt,
-              approvedAt: ad.approvedAt,
-              rejectedAt: ad.rejectedAt,
-              rejectionNote: ad.rejectionNote,
-              stats,
-              subscription: {
-                id: subscription.id,
-                status: subscription.status,
-                cancelAtPeriodEnd: subscription.cancelAtPeriodEnd,
-                currentPeriodStart: subscription.currentPeriodStart,
-                currentPeriodEnd: subscription.currentPeriodEnd,
-                createdAt: subscription.createdAt,
-                updatedAt: subscription.updatedAt,
-                tier: subscription.tier,
-                tierPrice: subscription.tierPrice,
-              },
+        return [
+          {
+            id: ad.id,
+            name: ad.name,
+            status: ad.status,
+            websiteUrl: ad.websiteUrl,
+            faviconUrl: ad.faviconUrl,
+            createdAt: ad.createdAt,
+            updatedAt: ad.updatedAt,
+            approvedAt: ad.approvedAt,
+            rejectedAt: ad.rejectedAt,
+            rejectionNote: ad.rejectionNote,
+            stats,
+            subscription: {
+              id: subscription.id,
+              status: subscription.status,
+              cancelAtPeriodEnd: subscription.cancelAtPeriodEnd,
+              currentPeriodStart: subscription.currentPeriodStart,
+              currentPeriodEnd: subscription.currentPeriodEnd,
+              createdAt: subscription.createdAt,
+              updatedAt: subscription.updatedAt,
+              tier: subscription.tier,
+              tierPrice: subscription.tierPrice,
             },
-          ]
-        })
-        .sort((first, second) => {
-          return second.updatedAt.getTime() - first.updatedAt.getTime()
-        })
+          },
+        ]
+      })
+
+      const paid = ads.filter(ad => isServingSubscription(ad.subscription.status))
 
       const totals = ads.reduce(
         (total, ad) => {
           const isActive =
-            ad.status === AdStatus.Approved && isActiveSubscriptionStatus(ad.subscription.status)
+            ad.status === AdStatus.Approved && isServingSubscription(ad.subscription.status)
 
           return {
+            ...total,
             ads: total.ads + 1,
             activeAds: total.activeAds + (isActive ? 1 : 0),
             activeSubscriptions:
-              total.activeSubscriptions +
-              (isActiveSubscriptionStatus(ad.subscription.status) ? 1 : 0),
+              total.activeSubscriptions + (isServingSubscription(ad.subscription.status) ? 1 : 0),
             impressions: total.impressions + ad.stats.impressions,
             clicks: total.clicks + ad.stats.clicks,
           }
@@ -246,6 +239,10 @@ export const advertiserRouter = {
           activeSubscriptions: 0,
           impressions: 0,
           clicks: 0,
+          // Normalized monthly revenue across paid subscriptions, matching
+          // the dashboard's revenue figure for this advertiser's slice.
+          monthlyCents: sumMonthlyCents(paid.map(ad => ad.subscription)),
+          currency: paid[0]?.subscription.tierPrice.currency ?? "usd",
         },
       )
 

--- a/packages/orpc/src/routers/dashboard.ts
+++ b/packages/orpc/src/routers/dashboard.ts
@@ -1,15 +1,8 @@
-import type { BillingInterval } from "@openads/db/client"
+import { isServingSubscription } from "@openads/db/lib/subscription"
 import { z } from "zod"
 import { authProcedure, workspaceMw } from "../index"
-
-const MONTHS_PER_INTERVAL: Record<BillingInterval, number> = {
-  Day: 1 / 30,
-  Week: 7 / 30,
-  Month: 1,
-  Year: 12,
-}
-
-const isPaid = (status: string) => status === "Active" || status === "Trialing"
+import { startOfUtcDay } from "../lib/date"
+import { sumMonthlyCents } from "../lib/revenue"
 
 export const dashboardRouter = {
   /**
@@ -21,13 +14,12 @@ export const dashboardRouter = {
     .input(z.object({ workspaceId: z.string() }))
     .use(workspaceMw)
     .handler(async ({ context: { db, workspace } }) => {
-      const since = new Date()
-      since.setUTCHours(0, 0, 0, 0)
-      since.setUTCDate(since.getUTCDate() - 29)
+      const since = startOfUtcDay(29)
 
       const [subscriptions, statRows] = await Promise.all([
         db.subscription.findMany({
           where: { workspaceId: workspace.id, ad: { isNot: null } },
+          orderBy: { ad: { createdAt: "desc" } },
           include: { ad: true, tier: true, tierPrice: true, advertiser: true },
         }),
         db.adStat.groupBy({
@@ -41,11 +33,7 @@ export const dashboardRouter = {
         }),
       ])
 
-      const paid = subscriptions.filter(sub => isPaid(sub.status))
-      const monthlyCents = paid.reduce((total, { tierPrice }) => {
-        const months = MONTHS_PER_INTERVAL[tierPrice.interval] * tierPrice.intervalCount
-        return total + tierPrice.amount / months
-      }, 0)
+      const paid = subscriptions.filter(sub => isServingSubscription(sub.status))
 
       const ads = subscriptions.flatMap(({ ad, ...subscription }) => {
         if (!ad) return []
@@ -68,8 +56,6 @@ export const dashboardRouter = {
         ]
       })
 
-      const byNewest = [...ads].sort((a, b) => b.createdAt.getTime() - a.createdAt.getTime())
-
       const series = statRows.map(row => ({
         date: row.date,
         impressions: row._sum.impressions ?? 0,
@@ -86,21 +72,22 @@ export const dashboardRouter = {
 
       return {
         revenue: {
-          monthlyCents: Math.round(monthlyCents),
+          monthlyCents: sumMonthlyCents(paid),
           currency: paid[0]?.tierPrice.currency ?? "usd",
           paidSubscriptions: paid.length,
         },
         counts: {
           ads: ads.length,
-          servingAds: ads.filter(ad => ad.status === "Approved" && isPaid(ad.subscription.status))
-            .length,
+          servingAds: ads.filter(
+            ad => ad.status === "Approved" && isServingSubscription(ad.subscription.status),
+          ).length,
           pastDueSubscriptions: subscriptions.filter(sub => sub.status === "PastDue").length,
           advertisers: new Set(subscriptions.map(sub => sub.advertiserId)).size,
         },
         series,
         totals,
-        pendingAds: byNewest.filter(ad => ad.status === "Pending"),
-        recentAds: byNewest.slice(0, 5),
+        pendingAds: ads.filter(ad => ad.status === "Pending"),
+        recentAds: ads.slice(0, 5),
       }
     }),
 }

--- a/packages/orpc/src/routers/storage.ts
+++ b/packages/orpc/src/routers/storage.ts
@@ -3,14 +3,16 @@ import { slugify } from "@dirstack/utils"
 import { ALLOWED_IMAGE_TYPES, MAX_UPLOAD_BYTES } from "@openads/db/schema"
 import { ORPCError } from "@orpc/server"
 import { z } from "zod"
-import { authProcedure, publicProcedure, workspaceMw } from "../index"
+import { authProcedure, publicProcedure } from "../index"
 
 const uploadImageInput = z.object({
-  file: z.string().trim().min(1, "File data is required"),
+  file: z
+    .string()
+    .trim()
+    .min(1, "File data is required")
+    .regex(/^data:[^;,]+;base64,/, "Expected a base64-encoded data URL"),
   fileName: z.string().trim().min(1, "File name is required"),
   contentType: z.string().trim().optional(),
-  cacheControl: z.string().trim().optional(),
-  metadata: z.record(z.string(), z.string()).optional(),
 })
 
 const generateObjectKey = (fileName: string) => {
@@ -30,42 +32,34 @@ const ADVERTISER_UPLOAD_WINDOW_SECONDS = 60 * 60
 export const storageRouter = {
   uploadUserImage: authProcedure
     .input(uploadImageInput)
-    .handler(
-      async ({ context: { s3, user }, input: { file, fileName, contentType, ...props } }) => {
-        // Same guardrails as the advertiser upload: derive the content type
-        // (explicit input wins over the data-URL prefix) and enforce the
-        // allowlist + size cap before anything touches storage.
-        const resolvedContentType = contentType || file.match(/^data:([^;,]+)[;,]/)?.[1]
+    .handler(async ({ context: { s3, user }, input: { file, fileName, contentType } }) => {
+      // Same guardrails as the advertiser upload: derive the content type
+      // (explicit input wins over the data-URL prefix) and enforce the
+      // allowlist + size cap before anything touches storage.
+      const resolvedContentType = contentType || file.match(/^data:([^;,]+)[;,]/)?.[1]
 
-        if (!resolvedContentType || !allowedImageTypes.has(resolvedContentType)) {
-          throw new ORPCError("BAD_REQUEST", {
-            message: "Unsupported file type. Use PNG, JPEG, or WebP.",
-          })
-        }
+      if (!resolvedContentType || !allowedImageTypes.has(resolvedContentType)) {
+        throw new ORPCError("BAD_REQUEST", {
+          message: "Unsupported file type. Use PNG, JPEG, or WebP.",
+        })
+      }
 
-        const body = Buffer.from(file.split(",")[1]!, "base64")
+      const body = Buffer.from(file.slice(file.indexOf(",") + 1), "base64")
 
-        if (body.byteLength > MAX_UPLOAD_BYTES) {
-          throw new ORPCError("BAD_REQUEST", {
-            message: "File is too large. Maximum upload size is 2 MB.",
-          })
-        }
+      if (body.byteLength > MAX_UPLOAD_BYTES) {
+        throw new ORPCError("BAD_REQUEST", {
+          message: "File is too large. Maximum upload size is 2 MB.",
+        })
+      }
 
-        const key = `users/${user.id}/${generateObjectKey(fileName)}`
+      const key = `users/${user.id}/${generateObjectKey(fileName)}`
 
-        return s3.uploadObject({ key, body, contentType: resolvedContentType, ...props })
-      },
-    ),
-
-  deleteUser: authProcedure.handler(async ({ context: { s3, user } }) => {
-    return await s3.deletePrefix({ prefix: `users/${user.id}` })
-  }),
-
-  deleteWorkspace: authProcedure
-    .input(z.object({ workspaceId: z.string() }))
-    .use(workspaceMw)
-    .handler(async ({ context: { s3, workspace } }) => {
-      return await s3.deletePrefix({ prefix: `workspaces/${workspace.id}` })
+      return s3.uploadObject({
+        key,
+        body,
+        contentType: resolvedContentType,
+        cacheControl: "public, max-age=31536000",
+      })
     }),
 
   // Anonymous endpoint: the Stripe Checkout session is the only auth, so
@@ -98,6 +92,20 @@ export const storageRouter = {
             })
           }
 
+          // Metered before the DB and Stripe round trips so replaying a known
+          // session id never gets unmetered upstream calls. Random-id probing
+          // would need a per-IP limit — out of scope here.
+          const rateKey = `storage:advertiser-upload:${sessionId}`
+          const count = await redis.incr(rateKey)
+          if (count === 1) {
+            await redis.expire(rateKey, ADVERTISER_UPLOAD_WINDOW_SECONDS)
+          }
+          if (count > ADVERTISER_UPLOAD_RATE_LIMIT) {
+            throw new ORPCError("TOO_MANY_REQUESTS", {
+              message: "Too many uploads from this checkout. Please try again later.",
+            })
+          }
+
           const workspace = await db.workspace.findUnique({
             where: { id: workspaceId },
             select: { id: true, stripeConnectId: true },
@@ -123,17 +131,6 @@ export const storageRouter = {
 
           if (session.metadata?.workspaceId !== workspaceId) {
             throw new ORPCError("BAD_REQUEST", { message: "Missing checkout metadata." })
-          }
-
-          const rateKey = `storage:advertiser-upload:${sessionId}`
-          const count = await redis.incr(rateKey)
-          if (count === 1) {
-            await redis.expire(rateKey, ADVERTISER_UPLOAD_WINDOW_SECONDS)
-          }
-          if (count > ADVERTISER_UPLOAD_RATE_LIMIT) {
-            throw new ORPCError("TOO_MANY_REQUESTS", {
-              message: "Too many uploads from this checkout. Please try again later.",
-            })
           }
 
           // Scoped to the workspace; the random key guarantees uniqueness. We don't

--- a/packages/orpc/src/routers/stripe.ts
+++ b/packages/orpc/src/routers/stripe.ts
@@ -1,8 +1,9 @@
 import { randomUUID } from "node:crypto"
 import { Prisma, StripeConnectStatus } from "@openads/db/client"
+import { SERVING_SUBSCRIPTION_STATUSES } from "@openads/db/lib/subscription"
 import { ORPCError } from "@orpc/server"
 import { z } from "zod"
-import { authProcedure, type Context, workspaceMw } from "../index"
+import { authProcedure, type Context, findMemberWorkspace, workspaceMw } from "../index"
 
 const STRIPE_OAUTH_STATE_TTL_SECONDS = 60 * 10
 
@@ -29,20 +30,13 @@ const hasDirectStripeData = (data: Prisma.JsonValue | null) => {
 }
 
 const resetWorkspaceStripeObjects = async (db: Context["db"], workspaceId: string) => {
-  const tiers = await db.tier.findMany({
-    where: { workspaceId },
-    select: { id: true },
-  })
-
-  const tierIds = tiers.map(tier => tier.id)
-
   await db.$transaction([
     db.tier.updateMany({
       where: { workspaceId },
       data: { stripeProductId: null },
     }),
     db.tierPrice.updateMany({
-      where: { tierId: { in: tierIds } },
+      where: { tier: { workspaceId } },
       data: { stripePriceId: null },
     }),
   ])
@@ -74,7 +68,8 @@ export const stripeRouter = {
 
     callback: authProcedure
       .input(z.object({ code: z.string().min(1), state: z.string().min(1) }))
-      .handler(async ({ context: { db, redis, stripe, user }, input: { code, state } }) => {
+      .handler(async ({ context, input: { code, state } }) => {
+        const { db, redis, stripe, user } = context
         const stateKey = getOAuthStateKey(state)
         const storedState = await redis.get(stateKey)
 
@@ -92,13 +87,7 @@ export const stripeRouter = {
           throw new ORPCError("FORBIDDEN")
         }
 
-        const workspace = await db.workspace.findFirst({
-          where: { AND: [{ id: parsedState.workspaceId }, db.workspace.belongsTo(user.id)] },
-        })
-
-        if (!workspace) {
-          throw new ORPCError("FORBIDDEN")
-        }
+        const workspace = await findMemberWorkspace(context, parsedState.workspaceId)
 
         const token = await stripe.oauth.token({
           grant_type: "authorization_code",
@@ -150,7 +139,7 @@ export const stripeRouter = {
         const activeSubscriptions = await db.subscription.count({
           where: {
             workspaceId: workspace.id,
-            status: { in: ["Active", "Trialing"] },
+            status: { in: SERVING_SUBSCRIPTION_STATUSES },
           },
         })
 

--- a/packages/orpc/src/routers/tier-price.ts
+++ b/packages/orpc/src/routers/tier-price.ts
@@ -1,3 +1,4 @@
+import { Prisma } from "@openads/db"
 import { idSchema, tierPriceSchema } from "@openads/db/schema"
 import { archivePrice, createTierPrice } from "@openads/stripe/products"
 import { ORPCError } from "@orpc/server"
@@ -21,34 +22,57 @@ export const tierPriceRouter = {
         throw new ORPCError("NOT_FOUND", { message: "Tier not found." })
       }
 
-      // Amount is intentionally not part of the uniqueness key — that's the
-      // field you change by archive-and-create.
-      const conflict = await db.tierPrice.findFirst({
-        where: {
-          tierId: tier.id,
-          interval: input.interval,
-          intervalCount: input.intervalCount,
-          currency: input.currency,
-          isActive: true,
-        },
-      })
+      // Check-then-create runs serializably so two concurrent submits can't
+      // both pass the check and mint duplicate active prices (and duplicate
+      // live Stripe Prices). The Stripe call stays outside the transaction —
+      // never hold a serializable transaction across a network round trip.
+      // The durable fix is a partial unique index, deferred until migrations
+      // are adopted.
+      const tierPrice = await db
+        .$transaction(
+          async tx => {
+            // Amount is intentionally not part of the uniqueness key — that's
+            // the field you change by archive-and-create.
+            const conflict = await tx.tierPrice.findFirst({
+              where: {
+                tierId: tier.id,
+                interval: input.interval,
+                intervalCount: input.intervalCount,
+                currency: input.currency,
+                isActive: true,
+              },
+            })
 
-      if (conflict) {
-        throw new ORPCError("CONFLICT", {
-          message:
-            "An active price already exists for this interval and currency. Archive it before creating a replacement.",
+            if (conflict) {
+              throw new ORPCError("CONFLICT", {
+                message:
+                  "An active price already exists for this interval and currency. Archive it before creating a replacement.",
+              })
+            }
+
+            return await tx.tierPrice.create({
+              data: {
+                tierId: tier.id,
+                interval: input.interval,
+                intervalCount: input.intervalCount,
+                amount: input.amount,
+                currency: input.currency,
+              },
+            })
+          },
+          { isolationLevel: "Serializable" },
+        )
+        .catch(err => {
+          // P2034 = serialization failure: the concurrent submit won the race,
+          // so surface the same conflict error a sequential check would have.
+          if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2034") {
+            throw new ORPCError("CONFLICT", {
+              message:
+                "An active price already exists for this interval and currency. Archive it before creating a replacement.",
+            })
+          }
+          throw err
         })
-      }
-
-      const tierPrice = await db.tierPrice.create({
-        data: {
-          tierId: tier.id,
-          interval: input.interval,
-          intervalCount: input.intervalCount,
-          amount: input.amount,
-          currency: input.currency,
-        },
-      })
 
       const stripePrice = await createTierPrice(stripe, {
         connectedAccountId: workspace.stripeConnectId,

--- a/packages/orpc/src/routers/workspace.ts
+++ b/packages/orpc/src/routers/workspace.ts
@@ -90,10 +90,17 @@ export const workspaceRouter = {
   delete: authProcedure
     .input(z.object({ workspaceId: z.string() }))
     .use(workspaceMw)
-    .handler(async ({ context: { db }, input: { workspaceId } }) => {
+    .handler(async ({ context: { db, s3, logger }, input: { workspaceId } }) => {
       const workspace = await db.workspace.delete({
         where: { id: workspaceId },
       })
+
+      // Best-effort R2 cleanup of everything re-hosted under the workspace
+      // prefix (favicons, advertiser uploads). Runs after the DB delete so a
+      // failed delete never destroys live assets, and never fails the mutation.
+      await s3
+        .deletePrefix({ prefix: `workspaces/${workspaceId}` })
+        .catch(err => logger.warn("workspace: R2 cleanup failed", { err, workspaceId }))
 
       return workspace
     }),


### PR DESCRIPTION
Part of a whole-codebase DHH-style review run via multi-agent workflow: 89 findings survived adversarial verification, applied across 8 themed PRs. Every finding below was checked against the actual code before being fixed.

## Findings addressed

- **[high]** `apps/app/src/routes/$workspaceId/advertisers/$advertiserId.tsx:53` — **monthly-revenue-recomputed-client-side**: This is feature envy at its purest: MONTHS_PER_INTERVAL and the normalize-to-monthly reduce are copied wholesale from packages/orpc/src/routers/dashboard.ts and re-run in a route component. The procedure already computes `totals` server-side — why does revenue get second-class treatment?
- **[high]** `packages/orpc/src/routers/ad.ts:180` — **unscoped-tierprice-lookup-in-checkout-info**: createFromCheckout verifies `tierPrice.tier.workspaceId !== workspaceId` (line 271); getCheckoutInfo just trusts whatever tierPriceId the session metadata carries. A publisher controls their own connected account's session metadata, so this reads another tenant's tierPrice. Scope it like its sibling does.
- `packages/orpc/src/routers/dashboard.ts:12` — **active-trialing-predicate-duplicated-everywhere**: Same domain concept under three names: `isPaid(status: string)` here (stringly typed, no less), `isActiveSubscriptionStatus` in advertiser.ts, inline `[Active, Trialing]` arrays in advertiser.ts:62, stripe.ts:153, ad-serving.ts:70, plus two more copies in apps/app. One concept, seven spellings — this should boil down to one place.
- `packages/orpc/src/routers/advertiser.ts:224` — **js-sort-belongs-in-prisma-orderby**: Fetches subscriptions ordered by `createdAt`, then re-sorts the mapped ads by `ad.updatedAt` in application code. getAll already does this in the query — line 51, `orderBy: { ad: { updatedAt: "desc" } }`. Feature envy for work the database does for free.
- `packages/orpc/src/routers/ad.ts:452` — **utc-day-bucket-math-pasted-five-times**: The `new Date(); setUTCHours(0,0,0,0); setUTCDate(getUTCDate() - (days - 1))` incantation appears here, in advertiser.ts:137, dashboard.ts:24, ad-serving.ts:124, and ad-tracking.ts:19. Fiddly date math is exactly the kind of thing that drifts — one off-by-one in one copy and the dashboards disagree.
- `packages/orpc/src/routers/ad.ts:384` — **third-workspace-fetch-in-one-handler**: getConnectedCheckoutSession already fetched the workspace at the top of this handler; getCheckoutInfo fetches it again with a different select; createFromCheckout fetches it a third time just for `name`. Three round trips for one row that hasn't changed.
- `packages/orpc/src/routers/dashboard.ts:71` — **copy-and-sort-instead-of-orderby**: `[...ads].sort(...)` by ad createdAt after fetching unordered subscriptions. Prisma orders by to-one relation fields fine — advertiser.ts does `orderBy: { ad: { updatedAt: "desc" } }` already. Push it into the query and the copy + sort evaporate.
- `packages/orpc/src/routers/advertiser.ts:20` — **re-trimming-an-already-trimmed-input**: `query?.trim()` — the Zod schema already says `z.string().trim().optional()`. Trimming a trimmed string is defensive design; the validator is the contract.
- `packages/orpc/src/routers/storage.ts:60` — **dead-storage-delete-procedures-orphaned-r2**: `storage.deleteUser` and `storage.deleteWorkspace` have zero callers anywhere in the repo — and meanwhile `workspace.delete` (the thing users actually invoke) leaves every R2 object under `workspaces/{id}/` orphaned. Dead endpoints AND a missing cleanup, the worst of both.
- `packages/orpc/src/routers/storage.ts:128` — **rate-limit-after-expensive-stripe-call**: The comment says "rate-limit per session to bound abuse from a leaked session id", but the limiter increments AFTER the DB lookup and the Stripe `sessions.retrieve` round-trip. An attacker with a session id (or just random ids) gets unmetered Stripe API calls — the cheap gate is guarding the wrong door.
- `packages/orpc/src/routers/storage.ts:46` — **non-null-assertion-on-data-url-split**: `file.split(",")[1]!` — when would this ever be safe? Send raw base64 without a `data:` prefix and `Buffer.from(undefined)` throws a TypeError, turning a malformed input into a 500 instead of a 400. The `!` is papering over a type the schema should have enforced.
- `packages/orpc/src/routers/storage.ts:12` — **client-controlled-cache-control-and-metadata**: Why does the browser get to dictate the server's storage cache policy? `cacheControl` is passed from profile-form and `metadata` has no caller at all — YAGNI flexibility that lets any authed client set arbitrary cache headers and S3 metadata on our bucket.
- `packages/orpc/src/lib/ad-serving.ts:187` — **findServingAd-duplicates-findServingAds**: `findServingAd` has no production caller — `ad.ts` only uses `findServingAds` — and it re-implements the fetch/short-circuit/pick pipeline its plural sibling already owns. Dead weight kept alive by its own tests.
- `packages/orpc/src/routers/tier-price.ts:26` — **app-level-uniqueness-check-race**: findFirst-then-create for the one-active-price-per-shape invariant — two concurrent requests both pass the check and you end up with duplicate active prices and two live Stripe Prices. The database should be the bouncer here, not a read-then-hope.
- `packages/orpc/src/routers/stripe.ts:31` — **reset-stripe-objects-extra-query**: Fetching all tier ids just to feed them back into `tierId: { in: tierIds }` is a query Prisma can write itself — the relation filter does this in one go and the standalone read outside the transaction is a tiny consistency hole besides.
- `packages/orpc/src/routers/stripe.ts:95` — **callback-duplicates-findMemberWorkspace**: This `findFirst({ AND: [{ id }, belongsTo(user.id)] })` + FORBIDDEN dance is exactly `findMemberWorkspace` from index.ts, re-typed by hand because the helper isn't exported. Tenant-scoping logic should boil down to one place — the next person to fork it will get it subtly wrong.
- `packages/orpc/src/index.ts:137` — **workspace-type-golf**: `NonNullable<Awaited<ReturnType<typeof db.workspace.findFirst>>>` is type golf for a type Prisma already exports by name. Three wrappers deep to say "Workspace".
- `packages/orpc/src/lib/ad-tracking.ts:52` — **db-existence-check-before-rate-limit**: The ad existence lookup hits Postgres on every tracking call — including the ones the limiter is about to reject. The cheap Redis gate should run first; as written, a flood of requests for a valid adId still does a DB read per request.

## Verification

bun run lint (oxlint, 0 warnings/errors), bun run check-types (all 17 turbo tasks pass, incl. @openads/orpc, @openads/app, @openads/api), and bun test (22 pass / 0 fail across 7 files — baseline before changes was 16 pass / 0 fail in packages/orpc; the repo-wide run covers all suites). Tree is clean on dhh/orpc-server-cleanups; nothing pushed.

## Notes

All 18 confirmed findings applied per their refinedFix details, following the verifier guidance throughout. New shared modules: packages/db/src/lib/subscription.ts (SERVING_SUBSCRIPTION_STATUSES + isServingSubscription, imported from the bundle-safe Prisma browser entry, mutable array so Prisma `in:` filters type-check), packages/orpc/src/lib/date.ts (startOfUtcDay with the Math.max clamp folded in), packages/orpc/src/lib/revenue.ts (sumMonthlyCents). advertiser.getById now returns monthlyCents + currency (fallback "usd") inside totals, and the advertiser detail route renders formatPrice(totals.monthlyCents, totals.currency) gated on totals.activeSubscriptions > 0 — the edit to apps/app/src/routes/$workspaceId/advertisers/$advertiserId.tsx was kept minimal (deleted local math, predicate swap at the row component) since another branch touches that file. getCheckoutInfo's response keeps its exact prior shape (workspace picked to id/name/slug/faviconUrl so stripeConnectId never leaks from the unauthenticated procedure). storage.deleteUser/deleteWorkspace removed (zero callers, verified); workspace.delete now does best-effort s3.deletePrefix (which exists in @openads/s3) after the DB delete, logged on failure; user-prefix cleanup deferred — no account-deletion flow exists yet. tier-price create wraps only findFirst+create in a Serializable transaction (Stripe call stays outside) and maps P2034 to the existing CONFLICT error; the durable partial-unique-index fix is deferred until migrations are adopted per CLAUDE.md. The ad-serving tests pass unchanged with findServingAd as a findServingAds({count:1}) wrapper. The tracking rate-limit-first swap means nonexistent adIds now consume rate-limit budget (intended, noted in the finding).

## Merge order

Merge the app dashboard dedup PR first; rebase this one if GitHub reports a conflict on `$workspaceId/advertisers/$advertiserId.tsx`.
