### PR TITLE
fix(api): webhook logging, CORS edge caching, and error-handler fixes

### DIFF
--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,4 +1,4 @@
-import { appRouter, publicRouter } from "@openads/orpc/router"
+import { ADS_CURRENT_PATH, appRouter, publicRouter } from "@openads/orpc/router"
 import { OpenAPIHandler } from "@orpc/openapi/fetch"
 import { OpenAPIReferencePlugin } from "@orpc/openapi/plugins"
 import { onError as onORPCError } from "@orpc/server"
@@ -87,7 +87,10 @@ app.use("/rpc/*", async (c, next) => {
   await next()
 })
 
-const adsCurrentPath = /^\/v1\/workspaces\/[^/]+\/ads\/current$/
+// Derived from the route's own path declaration so the cache rule below can't
+// silently drift if the route moves. OpenAPI `{param}` templates become
+// single-segment wildcards.
+const adsCurrentPath = new RegExp(`^/v1${ADS_CURRENT_PATH.replaceAll(/\{[^}]+\}/g, "[^/]+")}$`)
 
 // Public REST + OpenAPI surface (`/v1/openapi.json`, `/v1/docs`, plus the routed
 // procedures themselves). Consumed by `@openads/sdk` and any third-party API

--- a/apps/api/src/middleware/cors.ts
+++ b/apps/api/src/middleware/cors.ts
@@ -2,11 +2,12 @@ import type { MiddlewareHandler } from "hono"
 import { cors } from "hono/cors"
 import { env } from "~/env"
 
-// Public REST surface: any origin (ads/tracking are public), but NO credentials
-// — these endpoints take no cookies, so a reflected origin + credentials would
-// needlessly widen the surface.
+// Public REST surface: static `*`, no credentials — these endpoints take no
+// cookies, and a static ACAO keeps the /v1 edge cache shared (a reflected
+// origin would force Vary: Origin, fragmenting or poisoning cached
+// ads/current responses).
 const v1Cors = cors({
-  origin: origin => origin || env.APP_URL,
+  origin: "*",
   allowHeaders: ["Content-Type", "Authorization"],
   allowMethods: ["POST", "GET", "OPTIONS"],
   maxAge: 86400,

--- a/apps/api/src/middleware/on-error.ts
+++ b/apps/api/src/middleware/on-error.ts
@@ -1,10 +1,10 @@
 import type { ErrorHandler } from "hono"
-import type { ContentfulStatusCode } from "hono/utils/http-status"
+import { HTTPException } from "hono/http-exception"
 import { env } from "~/env"
 import { logger } from "~/services/logger"
 
 export const onError: ErrorHandler = (err, c) => {
-  const status = "status" in err && err.status !== 200 ? err.status : 500
+  const status = err instanceof HTTPException ? err.status : 500
 
   logger.error(`unhandled error on ${c.req.method} ${c.req.path}`, {
     err,
@@ -18,6 +18,6 @@ export const onError: ErrorHandler = (err, c) => {
       message: err.message,
       stack: env.NODE_ENV === "production" ? undefined : err.stack,
     },
-    status as ContentfulStatusCode,
+    status,
   )
 }

--- a/apps/api/src/routes/log.ts
+++ b/apps/api/src/routes/log.ts
@@ -7,7 +7,6 @@
  * is allowed), so this is effectively a private endpoint.
  */
 
-import type { LogLevel } from "@openads/logger"
 import { LOG_LEVELS } from "@openads/logger"
 import { Hono } from "hono"
 import { z } from "zod"
@@ -30,7 +29,7 @@ const serializedErrorSchema: z.ZodType<{
 })
 
 const entrySchema = z.object({
-  level: z.enum(LOG_LEVELS as readonly [LogLevel, ...LogLevel[]]),
+  level: z.enum(LOG_LEVELS),
   message: z.string().max(MAX_MESSAGE_LENGTH),
   time: z.number().int().nonnegative(),
   context: z.record(z.string(), z.unknown()).optional(),

--- a/apps/api/src/routes/webhooks/stripe.ts
+++ b/apps/api/src/routes/webhooks/stripe.ts
@@ -13,14 +13,6 @@ import { stripe } from "~/services/stripe"
 
 export const stripeWebhookRoute = new Hono()
 
-// Must be the async variant: under the Bun runtime the Stripe SDK uses the
-// SubtleCrypto provider, whose HMAC is async-only — the synchronous
-// `constructEvent` throws "cannot be used in a synchronous context", which
-// would 400 every real webhook and break subscription sync.
-const constructStripeEvent = (body: string, signature: string) => {
-  return stripe.webhooks.constructEventAsync(body, signature, env.STRIPE_CONNECT_WEBHOOK_SECRET)
-}
-
 stripeWebhookRoute.post("/", async c => {
   const body = await c.req.text()
   const signature = c.req.header("stripe-signature")
@@ -31,10 +23,19 @@ stripeWebhookRoute.post("/", async c => {
 
   let event: Stripe.Event
 
+  // Must be the async variant: under the Bun runtime the Stripe SDK uses the
+  // SubtleCrypto provider, whose HMAC is async-only — the synchronous
+  // `constructEvent` throws "cannot be used in a synchronous context", which
+  // would 400 every real webhook and break subscription sync.
   try {
-    event = await constructStripeEvent(body, signature)
+    event = await stripe.webhooks.constructEventAsync(
+      body,
+      signature,
+      env.STRIPE_CONNECT_WEBHOOK_SECRET,
+    )
   } catch (err) {
-    return c.text(`Invalid signature: ${err}`, 400)
+    logger.warn("stripe webhook signature verification failed", { err })
+    return c.text("Invalid signature", 400)
   }
 
   try {

--- a/apps/api/src/routes/webhooks/stripe.ts
+++ b/apps/api/src/routes/webhooks/stripe.ts
@@ -1,5 +1,5 @@
 import { db } from "@openads/db"
-import { Prisma, StripeConnectStatus } from "@openads/db/client"
+import { Prisma, StripeConnectStatus, SubscriptionStatus } from "@openads/db/client"
 import {
   mapStripeSubscriptionStatus,
   readSubscriptionMetadata,
@@ -200,7 +200,7 @@ const markSubscriptionCanceled = async (
       workspace: { stripeConnectId: connectedAccountId },
     },
     data: {
-      status: "Canceled",
+      status: SubscriptionStatus.Canceled,
       cancelAtPeriodEnd: false,
     },
   })

--- a/packages/orpc/src/router.ts
+++ b/packages/orpc/src/router.ts
@@ -1,5 +1,7 @@
 import type { InferRouterInputs, InferRouterOutputs, RouterClient } from "@orpc/server"
 import { adRouter, getCurrentAds, recordClick, recordImpression } from "./routers/ad"
+
+export { ADS_CURRENT_PATH } from "./routers/ad"
 import { advertiserRouter } from "./routers/advertiser"
 import { authRouter } from "./routers/auth"
 import { dashboardRouter } from "./routers/dashboard"

--- a/packages/orpc/src/routers/ad.ts
+++ b/packages/orpc/src/routers/ad.ts
@@ -69,10 +69,14 @@ const getConnectedCheckoutSession = async ({
 
 // ---- SDK-facing public procedures (re-exported via `publicRouter`) ----
 
+// Exported so apps/api can derive its edge-cache path matcher from the same
+// declaration — keeping the route and the cache rule from silently drifting.
+export const ADS_CURRENT_PATH = "/workspaces/{slug}/ads/current"
+
 export const getCurrentAds = publicProcedure
   .route({
     method: "GET",
-    path: "/workspaces/{slug}/ads/current",
+    path: ADS_CURRENT_PATH,
     tags: ["Ads"],
     summary: "Fetch ads currently serving for a workspace",
   })


### PR DESCRIPTION
Part of a whole-codebase DHH-style review run via multi-agent workflow: 89 findings survived adversarial verification, applied across 8 themed PRs. Every finding below was checked against the actual code before being fixed.

## Findings addressed

- `apps/api/src/middleware/on-error.ts:7` — **duck-typed-status-instead-of-httpexception**: Duck-typing `"status" in err && err.status !== 200` plus an `as ContentfulStatusCode` cast is defensive design around a question Hono already answers. When would an Error ever carry status 200? Use the real type.
- `apps/api/src/routes/webhooks/stripe.ts:36` — **signature-failure-echoed-not-logged**: Backwards: the raw error gets interpolated into the 400 body for Stripe to read, while our own log file sees nothing. A rotated webhook secret would fail every delivery silently — you'd only find out from the Stripe dashboard.
- `apps/api/src/middleware/cors.ts:9` — **reflected-origin-fights-edge-cache**: Reflecting the request origin on a credential-less public surface is more clever than needed, and it actively fights the 5s edge cache on /v1 ads/current — reflected ACAO forces Vary: Origin, so every publisher origin gets its own cache entry. `*` is what this policy actually is; say so.
- `apps/api/src/routes/log.ts:32` — **unneeded-zod-enum-cast**: Type golf. LOG_LEVELS is already declared `as const` in @openads/logger, and Zod v4's `z.enum` takes a readonly tuple directly — the `as readonly [LogLevel, ...LogLevel[]]` cast widens the literals for no benefit.
- `apps/api/src/routes/webhooks/stripe.ts:20` — **one-caller-construct-event-wrapper**: Wrapper with one caller that only forwards arguments — not carrying its weight. The comment is the valuable part; the function isn't.
- `apps/api/src/routes/webhooks/stripe.ts:202` — **string-literal-where-enum-exists**: File imports `StripeConnectStatus` for one handler, then hand-writes `status: "Canceled"` in the next. Pick one domain language — the enum already exists.
- `apps/api/src/index.ts:91` — **cache-path-regex-duplicates-route-definition**: `adsCurrentPath` re-encodes the path declared in packages/orpc/src/routers/ad.ts:75 as a regex. Move the route and the edge cache silently evaporates — nothing breaks loudly. Duplication should boil down to one place.

## Verification

bun run lint (oxlint, 0 warnings/errors), bun run check-types (17/17 turbo tasks pass incl. @openads/api, @openads/orpc, @openads/app), bun test (22 pass, 0 fail). Also sanity-checked the derived edge-cache regex produces the exact same pattern as the old hardcoded one (^\\/v1\\/workspaces\\/[^/]+\\/ads\\/current$, matching/non-matching cases verified).

## Notes

Two behavior-affecting changes per the refined fixes: (1) /v1 CORS now sends a static ACAO `*` instead of reflecting the request origin — same security posture (no credentials on that surface), but it stops forcing Vary: Origin so the 5s edge cache on GET /v1/workspaces/{slug}/ads/current is shared across publisher origins instead of fragmented/poisoned; the cors.ts comment was rewritten to document this rationale. (2) Stripe webhook signature failures now return a generic "Invalid signature" 400 (no longer echoing the internal error to unauthenticated callers) and are logged via logger.warn with { err }, so a rotated STRIPE_CONNECT_WEBHOOK_SECRET is visible in apps/api/logs/openads.log. Also: app.onError now uses the canonical HTTPException instanceof check (fixes a latent crash where better-auth APIError's string `status` was force-cast to a numeric status code); ADS_CURRENT_PATH is exported from packages/orpc/src/routers/ad.ts (re-exported via router.ts) and apps/api derives its edge-cache path matcher from it, so route and cache rule can't drift. No findings skipped.
