### PR TITLE
refactor(db): schema simplifications and prefixed-id upsert fix

### DIFF
--- a/apps/api/src/routes/webhooks/stripe.ts
+++ b/apps/api/src/routes/webhooks/stripe.ts
@@ -78,11 +78,9 @@ const handleConnectAccountUpdate = async (account: Stripe.Account, connectedAcco
       stripeConnectStatus: account.charges_enabled
         ? StripeConnectStatus.Active
         : StripeConnectStatus.Pending,
-      stripeConnectEnabled: account.charges_enabled,
       stripeConnectData: {
         integrationMode: "direct",
         accountId: account.id,
-        chargesEnabled: account.charges_enabled,
       },
     },
   })
@@ -99,7 +97,6 @@ const handleConnectAccountDeauthorized = async (connectedAccountId?: string) => 
     data: {
       stripeConnectId: null,
       stripeConnectStatus: null,
-      stripeConnectEnabled: false,
       stripeConnectData: Prisma.JsonNull,
     },
   })

--- a/apps/app/src/components/ads/ad-form.tsx
+++ b/apps/app/src/components/ads/ad-form.tsx
@@ -1,3 +1,4 @@
+import { adCreativeSchema } from "@openads/db/schema"
 import { cx } from "@openads/ui/cva"
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@openads/ui/form"
 import { Input } from "@openads/ui/input"
@@ -53,9 +54,7 @@ const buildSchema = (fields: Field[]) => {
     metaShape[field.id] = schema
   }
 
-  return z.object({
-    name: z.string().trim().min(2, { message: "Name is too short" }),
-    websiteUrl: z.url(),
+  return adCreativeSchema.extend({
     meta: z.object(metaShape).optional().default({}),
   })
 }

--- a/apps/app/src/routes/$workspaceId/ads/$adId.tsx
+++ b/apps/app/src/routes/$workspaceId/ads/$adId.tsx
@@ -229,8 +229,12 @@ function AdReviewPage() {
 
             <dl className="divide-y divide-border/60 text-sm">
               <TimelineRow label="Submitted" date={ad.createdAt} />
-              {ad.approvedAt && <TimelineRow label="Approved" date={ad.approvedAt} />}
-              {ad.rejectedAt && <TimelineRow label="Rejected" date={ad.rejectedAt} />}
+              {ad.reviewedAt && ad.status !== "Pending" && (
+                <TimelineRow
+                  label={ad.status === "Approved" ? "Approved" : "Rejected"}
+                  date={ad.reviewedAt}
+                />
+              )}
             </dl>
 
             {ad.rejectionNote && (

--- a/packages/db/prisma/models/ad.prisma
+++ b/packages/db/prisma/models/ad.prisma
@@ -13,8 +13,9 @@ model Ad {
   websiteUrl String
   faviconUrl String @default("")
 
-  approvedAt    DateTime?
-  rejectedAt    DateTime?
+  // When the current status was decided; null while Pending. `status` says
+  // which way the review went.
+  reviewedAt    DateTime?
   rejectionNote String?
 
   createdAt DateTime @default(now())

--- a/packages/db/prisma/models/advertiser.prisma
+++ b/packages/db/prisma/models/advertiser.prisma
@@ -12,5 +12,4 @@ model Advertiser {
 
   // Indexes
   @@unique([workspaceId, email])
-  @@index([workspaceId])
 }

--- a/packages/db/prisma/models/field.prisma
+++ b/packages/db/prisma/models/field.prisma
@@ -39,6 +39,5 @@ model Meta {
 
   // Indexes
   @@unique([adId, fieldId])
-  @@index([adId])
   @@index([fieldId])
 }

--- a/packages/db/prisma/models/tier-price.prisma
+++ b/packages/db/prisma/models/tier-price.prisma
@@ -23,5 +23,4 @@ model TierPrice {
 
   // Indexes
   @@index([tierId, isActive])
-  @@index([stripePriceId])
 }

--- a/packages/db/prisma/models/workspace.prisma
+++ b/packages/db/prisma/models/workspace.prisma
@@ -1,7 +1,6 @@
 enum StripeConnectStatus {
   Pending
   Active
-  Rejected
 }
 
 model Workspace {
@@ -14,10 +13,9 @@ model Workspace {
   updatedAt  DateTime @updatedAt
 
   // Stripe Connect fields
-  stripeConnectId      String?              @unique // Stripe Connect account ID
-  stripeConnectStatus  StripeConnectStatus?
-  stripeConnectEnabled Boolean              @default(false)
-  stripeConnectData    Json? // Additional Stripe account data
+  stripeConnectId     String?              @unique // Stripe Connect account ID
+  stripeConnectStatus StripeConnectStatus?
+  stripeConnectData   Json? // Additional Stripe account data
 
   // Relations
   members       WorkspaceMember[]

--- a/packages/db/prisma/models/workspace.prisma
+++ b/packages/db/prisma/models/workspace.prisma
@@ -24,9 +24,6 @@ model Workspace {
   tiers         Tier[]
   fields        Field[]
   subscriptions Subscription[]
-
-  // Indexes
-  @@index([stripeConnectId])
 }
 
 enum WorkspaceMemberRole {

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -430,9 +430,8 @@ const seed = async () => {
         faviconUrl: faviconUrls.get(item.ad.websiteUrl) ?? "",
         status: item.ad.status,
         createdAt: submittedAt,
-        approvedAt:
-          item.ad.status === "Approved" ? new Date(Date.now() - reviewedDaysAgo * DAY) : null,
-        rejectedAt: item.ad.status === "Rejected" ? new Date(Date.now() - 2 * DAY) : null,
+        reviewedAt:
+          item.ad.status === "Pending" ? null : new Date(Date.now() - reviewedDaysAgo * DAY),
         rejectionNote: item.ad.rejectionNote,
         subscriptionId: subscription.id,
       },

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -177,8 +177,7 @@ const seed = async () => {
     },
   ] as const
 
-  const tiers: Record<string, { id: string }> = {}
-  const prices: Record<string, { id: string }> = {}
+  const prices: Record<string, { id: string; tierId: string }> = {}
   let priceSeq = 0
 
   for (const [order, { prices: tierPrices, features, ...data }] of tierData.entries()) {
@@ -191,7 +190,6 @@ const seed = async () => {
         stripeProductId: `prod_seed${String(order + 1).padStart(4, "0")}`,
       },
     })
-    tiers[data.name] = tier
 
     for (const price of tierPrices) {
       priceSeq += 1
@@ -403,7 +401,6 @@ const seed = async () => {
     const price = prices[item.price]
     if (!price) throw new Error(`Unknown price key: ${item.price}`)
 
-    const tierName = item.price.split("/")[0] as string
     const periodStart = new Date(Date.now() - 10 * DAY)
     const periodEnd = new Date(periodStart.getTime() + 30 * DAY)
 
@@ -417,7 +414,7 @@ const seed = async () => {
         currentPeriodStart: periodStart,
         currentPeriodEnd: periodEnd,
         workspaceId: workspace.id,
-        tierId: tiers[tierName]!.id,
+        tierId: price.tierId,
         tierPriceId: price.id,
         advertiserId: advertiser.id,
       },

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -96,7 +96,6 @@ const seed = async () => {
       faviconUrl: await seedFavicon("https://acme.directory"),
       stripeConnectId: "acct_seed0000000000000001",
       stripeConnectStatus: "Active",
-      stripeConnectEnabled: true,
     },
   })
 

--- a/packages/db/src/lib/extensions.ts
+++ b/packages/db/src/lib/extensions.ts
@@ -24,6 +24,14 @@ export const customIdExtension = Prisma.defineExtension({
         }
         return await query(args)
       },
+
+      // The id only applies on the insert branch — updates never touch it.
+      async upsert({ model, args, query }) {
+        const record = args.create as RecordData
+        const id = record.id || generateId(model)
+        if (id) record.id = id
+        return await query(args)
+      },
     },
   },
 })

--- a/packages/db/src/schema/ad.ts
+++ b/packages/db/src/schema/ad.ts
@@ -7,10 +7,3 @@ export const adCreativeSchema = z.object({
 })
 
 export type AdCreativeSchema = z.infer<typeof adCreativeSchema>
-
-export const adReviewSchema = z.object({
-  id: z.string().min(1),
-  rejectionNote: z.string().trim().optional(),
-})
-
-export type AdReviewSchema = z.infer<typeof adReviewSchema>

--- a/packages/orpc/src/index.ts
+++ b/packages/orpc/src/index.ts
@@ -1,6 +1,6 @@
 import type { Session } from "@openads/auth/server"
 import { Prisma, type db } from "@openads/db"
-import type { Workspace } from "@openads/db/client"
+import { StripeConnectStatus, type Workspace } from "@openads/db/client"
 import type { EmailClient } from "@openads/emails"
 import type { Logger } from "@openads/logger"
 import type { RedisClient } from "@openads/redis"
@@ -154,7 +154,10 @@ export const connectEnabledMw = os
   .middleware(({ context, next }) => {
     const { workspace } = context
 
-    if (!workspace.stripeConnectEnabled || !workspace.stripeConnectId) {
+    if (
+      workspace.stripeConnectStatus !== StripeConnectStatus.Active ||
+      !workspace.stripeConnectId
+    ) {
       throw new ORPCError("PRECONDITION_FAILED", {
         message: "Connect your Stripe account before creating tiers.",
       })

--- a/packages/orpc/src/routers/ad.review.test.ts
+++ b/packages/orpc/src/routers/ad.review.test.ts
@@ -89,8 +89,7 @@ describe("ad review actions", () => {
       where: { id: "ad_pending" },
       data: {
         status: "Approved",
-        approvedAt: expect.any(Date),
-        rejectedAt: null,
+        reviewedAt: expect.any(Date),
         rejectionNote: null,
       },
     })
@@ -114,8 +113,7 @@ describe("ad review actions", () => {
       where: { id: "ad_pending" },
       data: {
         status: "Rejected",
-        rejectedAt: expect.any(Date),
-        approvedAt: null,
+        reviewedAt: expect.any(Date),
         rejectionNote: "The landing page is not reachable.",
       },
     })

--- a/packages/orpc/src/routers/ad.ts
+++ b/packages/orpc/src/routers/ad.ts
@@ -333,8 +333,7 @@ const createFromCheckout = publicProcedure
           websiteUrl,
           // Resubmission re-enters the review queue.
           status: "Pending",
-          approvedAt: null,
-          rejectedAt: null,
+          reviewedAt: null,
           rejectionNote: null,
         },
       })
@@ -481,8 +480,7 @@ export const adRouter = {
         where: { id: ad.id },
         data: {
           status: AdStatus.Approved,
-          approvedAt: new Date(),
-          rejectedAt: null,
+          reviewedAt: new Date(),
           rejectionNote: null,
         },
       })
@@ -515,8 +513,7 @@ export const adRouter = {
           where: { id: ad.id },
           data: {
             status: AdStatus.Rejected,
-            rejectedAt: new Date(),
-            approvedAt: null,
+            reviewedAt: new Date(),
             rejectionNote: note,
           },
         })
@@ -570,8 +567,9 @@ export const adRouter = {
         where: { id: ad.id },
         data: {
           status: AdStatus.Pending,
-          approvedAt: null,
-          rejectedAt: null,
+          reviewedAt: null,
+          // Unlike a resubmission, the note stays so the advertiser can see
+          // what to change.
           rejectionNote: note,
         },
       })

--- a/packages/orpc/src/routers/ad.ts
+++ b/packages/orpc/src/routers/ad.ts
@@ -1,4 +1,5 @@
 import { AdStatus, type Prisma, WorkspaceMemberRole } from "@openads/db/client"
+import { adCreativeSchema } from "@openads/db/schema"
 import {
   renderAdApproved,
   renderAdChangesRequested,
@@ -14,12 +15,12 @@ import { findServingAds, servingAdSchema } from "../lib/ad-serving"
 import { recordAdClick, recordAdImpression } from "../lib/ad-tracking"
 import { startOfUtcDay } from "../lib/date"
 
-const createFromCheckoutInput = z.object({
+// oRPC allows only one `.input()` per procedure, so the full shape is declared
+// up front. `name`/`websiteUrl` validation is shared with the ad form via
+// `adCreativeSchema`.
+const createFromCheckoutInput = adCreativeSchema.extend({
   workspaceId: z.string().min(1),
   sessionId: z.string().min(1),
-  name: z.string().trim().min(2),
-  // http(s) only — rendered as hrefs in the publisher dashboard
-  websiteUrl: z.url({ protocol: /^https?$/ }),
   meta: z
     .array(z.object({ fieldId: z.string(), value: z.unknown() }))
     .optional()

--- a/packages/orpc/src/routers/advertiser.ts
+++ b/packages/orpc/src/routers/advertiser.ts
@@ -197,8 +197,7 @@ export const advertiserRouter = {
             faviconUrl: ad.faviconUrl,
             createdAt: ad.createdAt,
             updatedAt: ad.updatedAt,
-            approvedAt: ad.approvedAt,
-            rejectedAt: ad.rejectedAt,
+            reviewedAt: ad.reviewedAt,
             rejectionNote: ad.rejectionNote,
             stats,
             subscription: {

--- a/packages/orpc/src/routers/stripe.ts
+++ b/packages/orpc/src/routers/stripe.ts
@@ -116,11 +116,9 @@ export const stripeRouter = {
             stripeConnectStatus: account.charges_enabled
               ? StripeConnectStatus.Active
               : StripeConnectStatus.Pending,
-            stripeConnectEnabled: account.charges_enabled,
             stripeConnectData: {
               integrationMode: "direct",
               accountId: account.id,
-              chargesEnabled: account.charges_enabled,
             },
           },
         })
@@ -162,7 +160,6 @@ export const stripeRouter = {
           data: {
             stripeConnectId: null,
             stripeConnectStatus: null,
-            stripeConnectEnabled: false,
             stripeConnectData: Prisma.JsonNull,
           },
         })

--- a/packages/orpc/src/routers/tier.test.ts
+++ b/packages/orpc/src/routers/tier.test.ts
@@ -13,7 +13,7 @@ const createContext = ({
       isActive: true,
       workspace: {
         id: "ws_openads",
-        stripeConnectEnabled: true,
+        stripeConnectStatus: "Active",
         stripeConnectId: "acct_publisher",
       },
     },
@@ -99,7 +99,7 @@ describe("tier.public.createCheckout", () => {
         tier: {
           id: "tier_gold",
           isActive: false,
-          workspace: { stripeConnectEnabled: true, stripeConnectId: "acct_publisher" },
+          workspace: { stripeConnectStatus: "Active", stripeConnectId: "acct_publisher" },
         },
       },
     })
@@ -137,7 +137,7 @@ describe("tier.public.createCheckout", () => {
         tier: {
           id: "tier_gold",
           isActive: true,
-          workspace: { stripeConnectEnabled: false, stripeConnectId: null },
+          workspace: { stripeConnectStatus: null, stripeConnectId: null },
         },
       },
     })

--- a/packages/orpc/src/routers/tier.ts
+++ b/packages/orpc/src/routers/tier.ts
@@ -1,3 +1,4 @@
+import { StripeConnectStatus } from "@openads/db/client"
 import { idSchema, tierPriceSchema, tierSchema } from "@openads/db/schema"
 import { createSubscriptionCheckoutSession } from "@openads/stripe/checkout"
 import {
@@ -311,7 +312,10 @@ export const tierRouter = {
           throw new ORPCError("NOT_FOUND", { message: "Tier not available." })
         }
 
-        if (!workspace.stripeConnectEnabled || !workspace.stripeConnectId) {
+        if (
+          workspace.stripeConnectStatus !== StripeConnectStatus.Active ||
+          !workspace.stripeConnectId
+        ) {
           throw new ORPCError("PRECONDITION_FAILED", {
             message: "This publisher cannot accept payments yet.",
           })


### PR DESCRIPTION
Part of a whole-codebase DHH-style review run via multi-agent workflow: 89 findings survived adversarial verification, applied across 8 themed PRs. Every finding below was checked against the actual code before being fixed.

## Findings addressed

- **[high]** `packages/db/src/lib/extensions.ts:12` — **custom-id-extension-misses-upsert**: Extension only hooks create/createMany, but every production creation path is an upsert — checkout (db.advertiser.upsert / db.subscription.upsert / db.ad.upsert in packages/orpc/src/routers/ad.ts:277-313), the Stripe webhook (apps/api/src/routes/webhooks/stripe.ts:170,232), and adStat tracking (packages/orpc/src/lib/ad-tracking.ts:59). All of those fall through to the raw cuid() default, so the prefixed-ID convention only holds for rows created in dev. An abstraction that skips the paths that matter isn't carrying its weight.
- **[high]** `packages/db/prisma/models/workspace.prisma:19` — **stripe-connect-enabled-derivable-from-status**: Two columns, one fact. Every writer sets stripeConnectEnabled in lockstep with stripeConnectStatus (Active↔true, Pending/null↔false — see packages/orpc/src/routers/stripe.ts:127-130 and apps/api/src/routes/webhooks/stripe.ts:77-80), and stripeConnectData.chargesEnabled stores it a third time. Two writers keeping three copies in sync is a drift bug waiting to happen. And the Rejected enum value is written nowhere — dead.
- `packages/db/prisma/models/ad.prisma:16` — **approved-rejected-timestamps-should-be-reviewedat**: status already says which way the review went; approvedAt/rejectedAt force every writer to null the opposite timestamp by hand — ad.ts does the dance four times (326-327, 481-482, 515-516, 570-571) and the seed needs a comment to keep the trio consistent. Three columns that can disagree, encoding one fact.
- `packages/db/src/schema/ad.ts:3` — **dead-ad-schemas-while-validation-is-triplicated**: adCreativeSchema and adReviewSchema are exported and imported by exactly nobody. Meanwhile the same name/websiteUrl validation is hand-rolled in packages/orpc/src/routers/ad.ts:19-21 and again in apps/app/src/components/ads/ad-form.tsx:57-58 — and the form copy already drifted (plain z.url(), no http(s) protocol guard, the very thing the dead schema's comment warns about). Three definitions, one source of truth nowhere.
- `packages/db/prisma/models/workspace.prisma:31` — **index-duplicates-unique-constraint**: @@index([stripeConnectId]) on a column that's already @unique — the unique constraint IS an index. Same duplicate in tier-price.prisma:26 (@@index([stripePriceId]) under stripePriceId @unique). Postgres maintains both for nothing.
- `packages/db/prisma/models/advertiser.prisma:15` — **index-redundant-with-composite-unique-prefix**: @@index([workspaceId]) is the leftmost prefix of @@unique([workspaceId, email]) — Postgres already serves workspaceId lookups from the unique index. Same story for Meta in field.prisma:42: @@index([adId]) is the prefix of @@unique([adId, fieldId]).
- `packages/db/prisma/seed.ts:407` — **seed-rederives-tier-from-string-key**: item.price.split("/")[0] as string followed by tiers[tierName]!.id — a cast and a non-null assertion to re-derive a fact the database already handed back. tierPrice.create returns tierId; the prices map just throws it away by typing itself { id: string }.

## Verification

bun run lint (oxlint, 0 warnings/errors), bun run check-types (17/17 turbo tasks pass after bun run db:generate), bun test (22 pass / 0 fail across 7 files — tier.test.ts mocks and ad.review.test.ts assertions updated for the new shapes). Prisma client regenerated; db:push intentionally NOT run per instructions. Tree clean on branch, not pushed.

## Notes

Schema changes require `bun run db:push --accept-data-loss` after merge (drops Workspace.stripeConnectEnabled, replaces Ad.approvedAt/rejectedAt with Ad.reviewedAt, drops the StripeConnectStatus.Rejected enum value, and drops 4 redundant indexes), then restart `bun run dev` (Prisma client is cached in globalThis.prismaGlobal). Existing dev rows lose review timestamps (approvedAt/rejectedAt data is not migrated into reviewedAt — re-run `bun run db:seed` to repopulate). Behavior notes: (1) prefixed IDs now also apply to upsert create branches, so checkout/webhook/tracking rows get `adv_`/`sub_`/`ad_`/`stat_` ids instead of raw cuids; (2) stripeConnectData no longer stores chargesEnabled (was never read); (3) the ad review timeline in the dashboard shows a single Approved-or-Rejected row driven by status + reviewedAt; requestChanges keeps the review note while advertiser resubmission clears it (unchanged semantics, now via one timestamp); (4) the advertiser ad form now enforces http(s)-only websiteUrl client-side via the shared adCreativeSchema (previously plain z.url(), which let ftp:// etc. through to a server error); the internal advertiser.getAll RPC output field renamed approvedAt/rejectedAt -> reviewedAt (no public /v1 or SDK surface touched).

## Merge order & post-merge steps

This is the most cross-cutting PR of the set — **merge it last** and rebase it once the others land.

After merge:
1. `bun run db:push --accept-data-loss` (drops `Workspace.stripeConnectEnabled`, replaces `Ad.approvedAt`/`rejectedAt` with `reviewedAt`, drops the unused `Rejected` enum value and 4 redundant indexes)
2. Restart `bun run dev` (Prisma client is cached in `globalThis.prismaGlobal`)
3. `bun run db:seed` to repopulate review timestamps on the dev workspace
