### PR TITLE
feat(events): server-side analytics tracking in oRPC procedures

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,12 @@ VITE_WEB_URL="https://openads.co"
 VITE_OPENPANEL_CLIENT_ID=""
 VITE_COSSISTANT_PUBLIC_KEY=""
 
+# ---- Analytics (OpenPanel — server-side, used by the API) ----
+# Optional. Leave empty to disable: outside production the API logs events at
+# debug instead of sending them. Set both in production to track server events.
+OPENPANEL_CLIENT_ID=""
+OPENPANEL_SECRET_KEY=""
+
 # ---- Database ----
 # Docker: auto-wired to the bundled Postgres (ignored). Dev: your Postgres URL.
 DATABASE_URL=""

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -13,6 +13,7 @@
     "@openads/auth": "*",
     "@openads/db": "*",
     "@openads/emails": "*",
+    "@openads/events": "*",
     "@openads/logger": "*",
     "@openads/orpc": "*",
     "@openads/redis": "*",

--- a/apps/api/src/context.ts
+++ b/apps/api/src/context.ts
@@ -1,6 +1,7 @@
 import { db } from "@openads/db"
 import type { Context } from "@openads/orpc"
 import { env } from "~/env"
+import { analytics } from "~/services/analytics"
 import { auth as betterAuth } from "~/services/auth"
 import { emails } from "~/services/emails"
 import { logger } from "~/services/logger"
@@ -25,5 +26,5 @@ export const createContext = async ({
   const clientIp =
     headers.get("cf-connecting-ip") ?? headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? null
 
-  return { auth, clientIp, db, emails, logger, redis, s3, stripe, env }
+  return { auth, clientIp, analytics, db, emails, logger, redis, s3, stripe, env }
 }

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -1,6 +1,7 @@
 import { env as auth } from "@openads/auth/env"
 import { env as db } from "@openads/db/env"
 import { env as emails } from "@openads/emails/env"
+import { env as events } from "@openads/events/env"
 import { env as redis } from "@openads/redis/env"
 import { env as s3 } from "@openads/s3/env"
 import { env as stripe } from "@openads/stripe/env"
@@ -8,7 +9,7 @@ import { createEnv } from "@t3-oss/env-core"
 import { z } from "zod"
 
 export const env = createEnv({
-  extends: [auth, db, redis, stripe, s3, emails],
+  extends: [auth, db, redis, stripe, s3, emails, events],
 
   server: {
     NODE_ENV: z.enum(["development", "production"]).default("development"),

--- a/apps/api/src/services/analytics.ts
+++ b/apps/api/src/services/analytics.ts
@@ -1,0 +1,6 @@
+import { createAnalytics } from "@openads/events/server"
+import { logger } from "~/services/logger"
+
+// Single shared OpenPanel server client, handed to every request via the oRPC
+// context. Reads its credentials from env; no-ops to debug logs outside prod.
+export const analytics = createAnalytics({ logger })

--- a/bun.lock
+++ b/bun.lock
@@ -28,6 +28,7 @@
         "@openads/auth": "*",
         "@openads/db": "*",
         "@openads/emails": "*",
+        "@openads/events": "*",
         "@openads/logger": "*",
         "@openads/orpc": "*",
         "@openads/redis": "*",
@@ -193,8 +194,11 @@
       "name": "@openads/events",
       "version": "1.0.0",
       "dependencies": {
+        "@openads/logger": "*",
         "@openpanel/sdk": "^1.0.1",
         "@openpanel/web": "^1.4.1",
+        "@t3-oss/env-core": "^0.13.11",
+        "zod": "^4.4.3",
       },
       "devDependencies": {
         "@openads/tsconfig": "*",
@@ -223,6 +227,7 @@
         "@openads/auth": "*",
         "@openads/db": "*",
         "@openads/emails": "*",
+        "@openads/events": "*",
         "@openads/logger": "*",
         "@openads/redis": "*",
         "@openads/s3": "*",

--- a/packages/events/package.json
+++ b/packages/events/package.json
@@ -6,7 +6,8 @@
   "exports": {
     "./server": "./src/server.ts",
     "./client": "./src/client.ts",
-    "./events": "./src/events.ts"
+    "./events": "./src/events.ts",
+    "./env": "./src/env.ts"
   },
   "scripts": {
     "clean": "rm -rf .turbo node_modules",
@@ -16,8 +17,11 @@
     "typecheck": "bun run check-types"
   },
   "dependencies": {
+    "@openads/logger": "*",
     "@openpanel/sdk": "^1.0.1",
-    "@openpanel/web": "^1.4.1"
+    "@openpanel/web": "^1.4.1",
+    "@t3-oss/env-core": "^0.13.11",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@openads/tsconfig": "*",

--- a/packages/events/src/env.ts
+++ b/packages/events/src/env.ts
@@ -1,0 +1,17 @@
+import { createEnv } from "@t3-oss/env-core"
+import { z } from "zod"
+
+export const env = createEnv({
+  server: {
+    // Server-side OpenPanel credentials. Optional: when unset (local dev) the
+    // analytics client logs events at debug instead of sending them, so dev
+    // works without credentials or network. Required in production to track.
+    OPENPANEL_CLIENT_ID: z.string().optional(),
+    OPENPANEL_SECRET_KEY: z.string().optional(),
+  },
+
+  runtimeEnv: process.env,
+
+  // Treat empty strings as unset so blank values fall back to the dev no-op.
+  emptyStringAsUndefined: true,
+})

--- a/packages/events/src/events.ts
+++ b/packages/events/src/events.ts
@@ -9,4 +9,28 @@ export const LogEvents = {
     name: "Create Workspace",
     channel: "workspace",
   },
+  CreateTier: {
+    name: "Create Tier",
+    channel: "tier",
+  },
+  SubmitAd: {
+    name: "Submit Ad",
+    channel: "ad",
+  },
+  ApproveAd: {
+    name: "Approve Ad",
+    channel: "ad",
+  },
+  RejectAd: {
+    name: "Reject Ad",
+    channel: "ad",
+  },
+  StartSubscription: {
+    name: "Start Subscription",
+    channel: "subscription",
+  },
+  CancelSubscription: {
+    name: "Cancel Subscription",
+    channel: "subscription",
+  },
 } satisfies Record<string, LogEvent>

--- a/packages/events/src/server.ts
+++ b/packages/events/src/server.ts
@@ -1,44 +1,55 @@
-import { OpenPanel, type TrackProperties } from "@openpanel/sdk"
+import type { Logger } from "@openads/logger"
+import { type IdentifyPayload, OpenPanel, type TrackProperties } from "@openpanel/sdk"
+import { env } from "./env"
 
-type Props = {
-  userId?: string
-  fullName?: string | null
-}
+export type AnalyticsClient = ReturnType<typeof createAnalytics>
 
-const runInBackground = (promise: Promise<unknown> | undefined) => {
-  promise?.catch(error => console.error("Analytics task failed:", error))
-}
+export type TrackEvent = { event: string } & TrackProperties
 
-export const setupAnalytics = async (options?: Props) => {
-  const { userId, fullName } = options ?? {}
+/**
+ * Server-side OpenPanel client, instantiated once and shared via the oRPC
+ * context (like `db` / `emails` / `s3`). Outside production — or when the
+ * OpenPanel credentials are unset — events are logged at debug instead of
+ * sent, so local dev and tests never depend on credentials or network.
+ *
+ * The logger is injected so the package reuses the caller's singleton
+ * (`apps/api`) instead of spinning up a second pino instance.
+ */
+export const createAnalytics = ({ logger }: { logger: Logger }) => {
+  const log = logger.child({ service: "analytics" })
 
-  const client = new OpenPanel({
-    clientId: process.env.NEXT_PUBLIC_OPENPANEL_CLIENT_ID ?? "",
-    clientSecret: process.env.OPENPANEL_SECRET_KEY ?? "",
-  })
-
-  if (userId && fullName) {
-    const [firstName, lastName] = fullName.split(" ")
-
-    runInBackground(
-      client.identify({
-        profileId: userId,
-        firstName,
-        lastName,
-      }),
-    )
+  // Analytics are best-effort and must never fail or slow down a mutation, so
+  // every network call is fired and forgotten. Failures only land in the logs.
+  const runInBackground = (promise: Promise<unknown> | undefined) => {
+    promise?.catch(err => log.error("analytics task failed", { err }))
   }
 
+  const { OPENPANEL_CLIENT_ID, OPENPANEL_SECRET_KEY } = env
+  const enabled =
+    process.env.NODE_ENV === "production" && !!OPENPANEL_CLIENT_ID && !!OPENPANEL_SECRET_KEY
+
+  const client = enabled
+    ? new OpenPanel({ clientId: OPENPANEL_CLIENT_ID!, clientSecret: OPENPANEL_SECRET_KEY! })
+    : null
+
   return {
-    track: (options: { event: string } & TrackProperties) => {
-      if (process.env.NODE_ENV !== "production") {
-        console.log("Track", options)
+    // Pass `profileId` to attribute the event to the authed user where known.
+    track: ({ event, ...properties }: TrackEvent) => {
+      if (!client) {
+        log.debug("track (analytics disabled)", { event, ...properties })
         return
       }
 
-      const { event, ...rest } = options
+      runInBackground(client.track(event, properties))
+    },
 
-      runInBackground(client.track(event, rest))
+    identify: (payload: IdentifyPayload) => {
+      if (!client) {
+        log.debug("identify (analytics disabled)", { profileId: payload.profileId })
+        return
+      }
+
+      runInBackground(client.identify(payload))
     },
   }
 }

--- a/packages/orpc/package.json
+++ b/packages/orpc/package.json
@@ -16,6 +16,7 @@
     "@openads/auth": "*",
     "@openads/db": "*",
     "@openads/emails": "*",
+    "@openads/events": "*",
     "@openads/logger": "*",
     "@openads/redis": "*",
     "@openads/s3": "*",

--- a/packages/orpc/src/index.ts
+++ b/packages/orpc/src/index.ts
@@ -2,6 +2,7 @@ import type { Session } from "@openads/auth/server"
 import { Prisma, type db } from "@openads/db"
 import { StripeConnectStatus, type Workspace } from "@openads/db/client"
 import type { EmailClient } from "@openads/emails"
+import type { AnalyticsClient } from "@openads/events/server"
 import type { Logger } from "@openads/logger"
 import type { RedisClient } from "@openads/redis"
 import type { S3BucketClient } from "@openads/s3"
@@ -18,6 +19,7 @@ type AuthUser = NonNullable<Session>["user"]
 export type Context = {
   auth: Session | null
   clientIp: string | null
+  analytics: AnalyticsClient
   db: typeof db
   emails: EmailClient
   logger: Logger

--- a/packages/orpc/src/routers/ad.review.test.ts
+++ b/packages/orpc/src/routers/ad.review.test.ts
@@ -11,6 +11,7 @@ const createContext = ({
   const emailCalls: Array<unknown> = []
   const cancelCalls: Array<unknown> = []
   const warnCalls: Array<unknown> = []
+  const trackCalls: Array<{ event: string }> = []
 
   const workspace = {
     id: "ws_openads",
@@ -38,6 +39,12 @@ const createContext = ({
   const context = {
     auth: { user: { id: "user_owner" } },
     user: { id: "user_owner" },
+    analytics: {
+      track: (event: { event: string }) => {
+        trackCalls.push(event)
+      },
+      identify: () => {},
+    },
     db: {
       workspace: {
         belongsTo: () => ({}),
@@ -72,12 +79,12 @@ const createContext = ({
     },
   } as unknown as Context
 
-  return { context, updateCalls, emailCalls, cancelCalls, warnCalls }
+  return { context, updateCalls, emailCalls, cancelCalls, warnCalls, trackCalls }
 }
 
 describe("ad review actions", () => {
   it("approves an ad and emails the advertiser", async () => {
-    const { context, updateCalls, emailCalls } = createContext()
+    const { context, updateCalls, emailCalls, trackCalls } = createContext()
 
     const result = await adRouter.approve.callable({ context })({
       workspaceId: "ws_openads",
@@ -85,6 +92,7 @@ describe("ad review actions", () => {
     })
 
     expect(result.status).toBe("Approved")
+    expect(trackCalls.map(c => c.event)).toEqual(["Approve Ad"])
     expect(updateCalls[0]).toEqual({
       where: { id: "ad_pending" },
       data: {
@@ -100,7 +108,7 @@ describe("ad review actions", () => {
   })
 
   it("rejects an ad, cancels the connected-account subscription, and emails the advertiser", async () => {
-    const { context, updateCalls, emailCalls, cancelCalls } = createContext()
+    const { context, updateCalls, emailCalls, cancelCalls, trackCalls } = createContext()
 
     const result = await adRouter.reject.callable({ context })({
       workspaceId: "ws_openads",
@@ -109,6 +117,8 @@ describe("ad review actions", () => {
     })
 
     expect(result.status).toBe("Rejected")
+    // RejectAd fires immediately; CancelSubscription only after Stripe confirms.
+    expect(trackCalls.map(c => c.event)).toEqual(["Reject Ad", "Cancel Subscription"])
     expect(updateCalls[0]).toEqual({
       where: { id: "ad_pending" },
       data: {
@@ -125,7 +135,7 @@ describe("ad review actions", () => {
   })
 
   it("keeps rejection successful when Stripe cancellation fails and logs the failure", async () => {
-    const { context, warnCalls } = createContext({
+    const { context, warnCalls, trackCalls } = createContext({
       cancelSubscription: async () => {
         throw new Error("Stripe unavailable")
       },
@@ -138,6 +148,9 @@ describe("ad review actions", () => {
         note: "The creative violates our policy.",
       }),
     ).resolves.toHaveProperty("status", "Rejected")
+
+    // The ad is still rejected, but no CancelSubscription event since Stripe failed.
+    expect(trackCalls.map(c => c.event)).toEqual(["Reject Ad"])
 
     expect(warnCalls[0]).toMatchObject([
       "ad.reject: failed to cancel stripe subscription",

--- a/packages/orpc/src/routers/ad.ts
+++ b/packages/orpc/src/routers/ad.ts
@@ -7,6 +7,7 @@ import {
   AdRejected,
   renderTemplate,
 } from "@openads/emails"
+import { LogEvents } from "@openads/events/events"
 import { fetchAndUploadFavicon } from "@openads/s3/favicon"
 import { mapStripeSubscriptionStatus, toDate } from "@openads/stripe/subscription"
 import { ORPCError } from "@orpc/server"
@@ -234,7 +235,7 @@ const createFromCheckout = publicProcedure
   .input(createFromCheckoutInput)
   .handler(
     async ({
-      context: { db, emails, logger, s3, stripe, env },
+      context: { analytics, db, emails, logger, s3, stripe, env },
       input: { workspaceId, sessionId, name, websiteUrl, meta },
     }) => {
       const { connectedAccountId, session, workspace } = await getConnectedCheckoutSession({
@@ -294,6 +295,13 @@ const createFromCheckout = publicProcedure
           email: customerEmail,
           name: name.slice(0, 80),
         },
+      })
+
+      // Track whether this is a brand-new subscription so resubmissions (which
+      // re-run this flow with the same session) don't re-fire StartSubscription.
+      const existingSubscription = await db.subscription.findUnique({
+        where: { stripeSubscriptionId: stripeSubscription.id },
+        select: { id: true },
       })
 
       // Idempotent — the Stripe webhook may have already created this row.
@@ -414,6 +422,26 @@ const createFromCheckout = publicProcedure
         )
       }
 
+      // Advertisers are anonymous (email-only), so these events carry no
+      // profileId — they're attributed to the workspace and tier instead.
+      analytics.track({
+        event: LogEvents.SubmitAd.name,
+        channel: LogEvents.SubmitAd.channel,
+        workspaceId,
+        tierId: tier.id,
+        adId: ad.id,
+      })
+
+      if (!existingSubscription) {
+        analytics.track({
+          event: LogEvents.StartSubscription.name,
+          channel: LogEvents.StartSubscription.channel,
+          workspaceId,
+          tierId: tier.id,
+          subscriptionId: subscription.id,
+        })
+      }
+
       return { adId: ad.id, subscriptionId: subscription.id }
     },
   )
@@ -479,42 +507,55 @@ export const adRouter = {
   approve: authProcedure
     .input(adIdentitySchema.extend({ note: z.string().trim().max(500).optional() }))
     .use(adMw)
-    .handler(async ({ context: { ad, db, emails, workspace }, input: { note } }) => {
-      const updated = await db.ad.update({
-        where: { id: ad.id },
-        data: {
-          status: AdStatus.Approved,
-          reviewedAt: new Date(),
-          rejectionNote: null,
-        },
-      })
-
-      const advertiserEmail = ad.subscription.advertiser.email
-      if (advertiserEmail) {
-        const { html, text } = await renderTemplate(
-          AdApproved({
-            workspaceName: workspace.name,
-            adName: ad.name,
-            approvalNote: note,
-          }),
-        )
-
-        await emails.send({
-          to: { email: advertiserEmail, name: ad.subscription.advertiser.name },
-          subject: `Your ad on ${workspace.name} is now live`,
-          html,
-          text,
+    .handler(
+      async ({ context: { ad, analytics, db, emails, user, workspace }, input: { note } }) => {
+        const updated = await db.ad.update({
+          where: { id: ad.id },
+          data: {
+            status: AdStatus.Approved,
+            reviewedAt: new Date(),
+            rejectionNote: null,
+          },
         })
-      }
 
-      return updated
-    }),
+        analytics.track({
+          event: LogEvents.ApproveAd.name,
+          channel: LogEvents.ApproveAd.channel,
+          profileId: user.id,
+          workspaceId: workspace.id,
+          adId: ad.id,
+        })
+
+        const advertiserEmail = ad.subscription.advertiser.email
+        if (advertiserEmail) {
+          const { html, text } = await renderTemplate(
+            AdApproved({
+              workspaceName: workspace.name,
+              adName: ad.name,
+              approvalNote: note,
+            }),
+          )
+
+          await emails.send({
+            to: { email: advertiserEmail, name: ad.subscription.advertiser.name },
+            subject: `Your ad on ${workspace.name} is now live`,
+            html,
+            text,
+          })
+        }
+
+        return updated
+      },
+    ),
 
   reject: authProcedure
     .input(adIdentitySchema.extend({ note: z.string().trim().min(1).max(500) }))
     .use(adMw)
     .handler(
-      async ({ context: { ad, db, emails, logger, stripe, workspace }, input: { note } }) => {
+      async ({
+        context: { ad, analytics, db, emails, logger, stripe, user, workspace },
+        input: { note },
+      }) => {
         const updated = await db.ad.update({
           where: { id: ad.id },
           data: {
@@ -522,6 +563,14 @@ export const adRouter = {
             reviewedAt: new Date(),
             rejectionNote: note,
           },
+        })
+
+        analytics.track({
+          event: LogEvents.RejectAd.name,
+          channel: LogEvents.RejectAd.channel,
+          profileId: user.id,
+          workspaceId: workspace.id,
+          adId: ad.id,
         })
 
         // Cancel the underlying Stripe subscription so the advertiser stops being billed.
@@ -535,6 +584,14 @@ export const adRouter = {
             {},
             { stripeAccount: workspace.stripeConnectId },
           )
+
+          analytics.track({
+            event: LogEvents.CancelSubscription.name,
+            channel: LogEvents.CancelSubscription.channel,
+            profileId: user.id,
+            workspaceId: workspace.id,
+            subscriptionId: ad.subscription.id,
+          })
         } catch (err) {
           // Subscription may already be canceled or otherwise inaccessible — leave
           // local state correct and surface the failure in logs only.

--- a/packages/orpc/src/routers/tier.ts
+++ b/packages/orpc/src/routers/tier.ts
@@ -1,5 +1,6 @@
 import { StripeConnectStatus } from "@openads/db/client"
 import { idSchema, tierPriceSchema, tierSchema } from "@openads/db/schema"
+import { LogEvents } from "@openads/events/events"
 import { createSubscriptionCheckoutSession } from "@openads/stripe/checkout"
 import {
   archivePrice,
@@ -63,7 +64,7 @@ export const tierRouter = {
     .use(connectEnabledMw)
     .handler(
       async ({
-        context: { db, stripe, workspace },
+        context: { analytics, db, stripe, user, workspace },
         input: { name, description, weight, isActive, order, features, initialPrices },
       }) => {
         // Create the Tier row first so we can stamp its id onto the Stripe Product metadata.
@@ -140,6 +141,14 @@ export const tierRouter = {
           await db.tier.delete({ where: { id: tier.id } })
           throw err
         }
+
+        analytics.track({
+          event: LogEvents.CreateTier.name,
+          channel: LogEvents.CreateTier.channel,
+          profileId: user.id,
+          workspaceId: workspace.id,
+          tierId: tier.id,
+        })
 
         // Stamp the Stripe Product id back onto the Tier and return with prices nested.
         return await db.tier.update({

--- a/packages/orpc/src/routers/workspace.ts
+++ b/packages/orpc/src/routers/workspace.ts
@@ -1,5 +1,6 @@
 import { WorkspaceMemberRole } from "@openads/db/client"
 import { idSchema, workspaceSchema } from "@openads/db/schema"
+import { LogEvents } from "@openads/events/events"
 import { fetchAndUploadFavicon } from "@openads/s3/favicon"
 import { z } from "zod"
 import { authProcedure, type Context, workspaceMw } from "../index"
@@ -54,6 +55,23 @@ export const workspaceRouter = {
         ...data,
         members: { create: { userId: context.user.id, role: WorkspaceMemberRole.Owner } },
       },
+    })
+
+    // Enrich the OpenPanel profile so server events are attributable to a
+    // named user, not just an id. Idempotent — safe to repeat per workspace.
+    const [firstName, ...rest] = (context.user.name ?? "").split(" ")
+    context.analytics.identify({
+      profileId: context.user.id,
+      email: context.user.email,
+      firstName,
+      lastName: rest.join(" ") || undefined,
+    })
+
+    context.analytics.track({
+      event: LogEvents.CreateWorkspace.name,
+      channel: LogEvents.CreateWorkspace.channel,
+      profileId: context.user.id,
+      workspaceId: workspace.id,
     })
 
     const refreshed = await refreshWorkspaceFavicon(context, {

--- a/packages/orpc/src/routers/workspace.ts
+++ b/packages/orpc/src/routers/workspace.ts
@@ -49,61 +49,68 @@ export const workspaceRouter = {
       })
     }),
 
-  create: authProcedure.input(workspaceSchema).handler(async ({ context, input: data }) => {
-    const workspace = await context.db.workspace.create({
-      data: {
-        ...data,
-        members: { create: { userId: context.user.id, role: WorkspaceMemberRole.Owner } },
-      },
-    })
+  create: authProcedure
+    .input(workspaceSchema)
+    .handler(async ({ context: { analytics, db, env, logger, s3, user }, input: data }) => {
+      const workspace = await db.workspace.create({
+        data: {
+          ...data,
+          members: { create: { userId: user.id, role: WorkspaceMemberRole.Owner } },
+        },
+      })
 
-    // Enrich the OpenPanel profile so server events are attributable to a
-    // named user, not just an id. Idempotent — safe to repeat per workspace.
-    const [firstName, ...rest] = (context.user.name ?? "").split(" ")
-    context.analytics.identify({
-      profileId: context.user.id,
-      email: context.user.email,
-      firstName,
-      lastName: rest.join(" ") || undefined,
-    })
+      // Enrich the OpenPanel profile so server events are attributable to a
+      // named user, not just an id. Idempotent — safe to repeat per workspace.
+      const [firstName, ...rest] = (user.name ?? "").split(" ")
+      analytics.identify({
+        profileId: user.id,
+        email: user.email,
+        firstName,
+        lastName: rest.join(" ") || undefined,
+      })
 
-    context.analytics.track({
-      event: LogEvents.CreateWorkspace.name,
-      channel: LogEvents.CreateWorkspace.channel,
-      profileId: context.user.id,
-      workspaceId: workspace.id,
-    })
+      analytics.track({
+        event: LogEvents.CreateWorkspace.name,
+        channel: LogEvents.CreateWorkspace.channel,
+        profileId: user.id,
+        workspaceId: workspace.id,
+      })
 
-    const refreshed = await refreshWorkspaceFavicon(context, {
-      workspaceId: workspace.id,
-      websiteUrl: workspace.websiteUrl,
-    })
+      const refreshed = await refreshWorkspaceFavicon(
+        { db, s3, logger, env },
+        { workspaceId: workspace.id, websiteUrl: workspace.websiteUrl },
+      )
 
-    return refreshed ?? workspace
-  }),
+      return refreshed ?? workspace
+    }),
 
   update: authProcedure
     .input(workspaceUpdateInput)
     .use(workspaceMw)
-    .handler(async ({ context, input: { workspaceId, ...data } }) => {
-      const websiteUrlChanged = data.websiteUrl !== context.workspace.websiteUrl
+    .handler(
+      async ({
+        context: { db, env, logger, s3, workspace: current },
+        input: { workspaceId, ...data },
+      }) => {
+        const websiteUrlChanged = data.websiteUrl !== current.websiteUrl
 
-      const workspace = await context.db.workspace.update({
-        where: { id: workspaceId },
-        data,
-      })
-
-      if (websiteUrlChanged) {
-        const refreshed = await refreshWorkspaceFavicon(context, {
-          workspaceId,
-          websiteUrl: workspace.websiteUrl,
+        const workspace = await db.workspace.update({
+          where: { id: workspaceId },
+          data,
         })
 
-        return refreshed ?? workspace
-      }
+        if (websiteUrlChanged) {
+          const refreshed = await refreshWorkspaceFavicon(
+            { db, s3, logger, env },
+            { workspaceId, websiteUrl: workspace.websiteUrl },
+          )
 
-      return workspace
-    }),
+          return refreshed ?? workspace
+        }
+
+        return workspace
+      },
+    ),
 
   delete: authProcedure
     .input(z.object({ workspaceId: z.string() }))


### PR DESCRIPTION
Closes #40.

## What

Wires the dormant `@openads/events` server entrypoint into the API so meaningful product events are tracked server-side, independent of the browser.

## Changes

- **`@openads/events`**
  - New `./env` t3-env file validating `OPENPANEL_CLIENT_ID` / `OPENPANEL_SECRET_KEY` (replaces the Next.js-era raw `process.env` reads).
  - `setupAnalytics` → `createAnalytics({ logger })`: instantiated once, logger injected (reuses the API's pino singleton), `console.*` replaced with `@openads/logger`. Outside production — or when credentials are unset — events log at `debug` instead of sending, so dev/tests need no credentials or network.
  - Expanded `LogEvents` beyond `CreateWorkspace`.
- **`@openads/orpc` / `apps/api`**: `analytics` added to the oRPC `Context` and built once in `apps/api/src/services/analytics.ts`, exposed like `db`/`emails`/`s3`.
- **Instrumentation** (after the mutation succeeds): `CreateWorkspace`, `CreateTier`, `SubmitAd`, `ApproveAd`, `RejectAd`, `StartSubscription` (only on a genuinely new subscription), `CancelSubscription` (only after Stripe confirms the cancel). Authed events carry `profileId`; `workspace.create` also calls `identify` to enrich the profile. Advertiser flows are anonymous, so they're attributed to workspace/tier instead.

## Notes

- `.env.example` documents the two new server vars.
- `StartSubscription`/`CancelSubscription` are fired only from oRPC procedures here (per the issue scope); the Stripe webhook path is untouched.

## Test plan

- [x] `bun run check-types`
- [x] `bun run lint`
- [x] `bun test` (added assertions to `ad.review.test.ts` covering the new events, incl. that `CancelSubscription` does not fire when Stripe cancellation fails)

🤖 Generated with [Claude Code](https://claude.com/claude-code)