### PR TITLE
feat(db): enforce one active TierPrice per shape with a partial unique index

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,6 +85,7 @@ Each Tier has many `TierPrice`s (one Stripe Product, many Stripe Prices). A tier
 - **Why**: Stripe Prices are immutable on `unit_amount` / `interval` / `currency`. Mirroring that on our side gives us an audit trail of price changes and lets old subscribers keep their grandfathered price even after the publisher raises rates. `Subscription` references a specific `TierPrice` via `Subscription.tierPriceId`, so archive ≠ break.
 - **Intervals supported**: `Day` / `Week` / `Month` / `Year` (matches `Stripe.recurring.interval`). `intervalCount` is on the schema with `default(1)` but isn't yet exposed in the form.
 - **Form input**: publishers type integer whole units (`19`); the form multiplies by 100 before submitting. DB and Stripe always see cents.
+- **One-active-price enforcement**: the "at most one active price per shape" rule is enforced in the DB by a **partial unique index** — `@@unique([tierId, interval, intervalCount, currency], where: raw("\"isActive\""))` on `TierPrice` (named `TierPrice_active_shape_key`). This needs the `partialIndexes` preview feature on the generator (Prisma ≥ 7.4) and is applied by `db:push` like any other index. `tierPrice.create` keeps a `findFirst` pre-check for the friendly error and catches `P2002` for the double-submit race.
 
 ## Out of scope at v1 (don't gold-plate)
 

--- a/packages/db/prisma/models/tier-price.prisma
+++ b/packages/db/prisma/models/tier-price.prisma
@@ -23,4 +23,10 @@ model TierPrice {
 
   // Indexes
   @@index([tierId, isActive])
+  // At most one ACTIVE price per (interval, intervalCount, currency) shape.
+  // Amount is deliberately not part of the key — changing it is archive +
+  // create-new. The partial `where` scopes uniqueness to active rows so
+  // archived prices (grandfathered subscriptions) don't collide. This is the
+  // durable guard behind the app-level check in `tierPrice.create`.
+  @@unique([tierId, interval, intervalCount, currency], where: raw("\"isActive\""), map: "TierPrice_active_shape_key")
 }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -4,6 +4,9 @@ datasource db {
 }
 
 generator client {
-  provider = "prisma-client"
-  output   = "../src/generated/prisma"
+  provider        = "prisma-client"
+  output          = "../src/generated/prisma"
+  // Lets `@@unique` carry a `where` predicate so we can express the partial
+  // unique index on TierPrice (one active price per shape) in the schema.
+  previewFeatures = ["partialIndexes"]
 }

--- a/packages/orpc/src/routers/tier-price.test.ts
+++ b/packages/orpc/src/routers/tier-price.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "bun:test"
+import { Prisma } from "@openads/db"
+import type { Context } from "../index"
+import { tierPriceRouter } from "./tier-price"
+
+const workspace = {
+  id: "ws_openads",
+  stripeConnectStatus: "Active",
+  stripeConnectId: "acct_publisher",
+}
+
+const tier = { id: "tier_gold", stripeProductId: "prod_gold", workspaceId: "ws_openads" }
+
+const p2002 = new Prisma.PrismaClientKnownRequestError("Unique constraint failed", {
+  code: "P2002",
+  clientVersion: "7.8.0",
+  meta: { target: "TierPrice_active_shape_key" },
+})
+
+const createContext = ({
+  existingConflict = null,
+  onCreate = async () => ({ id: "tier_price_new" }),
+}: {
+  existingConflict?: unknown
+  onCreate?: () => Promise<unknown>
+} = {}) => {
+  const context = {
+    auth: { user: { id: "user_owner" } },
+    user: { id: "user_owner" },
+    db: {
+      workspace: {
+        belongsTo: () => ({}),
+        findFirst: async () => workspace,
+      },
+      tier: { findFirst: async () => tier },
+      tierPrice: {
+        findFirst: async () => existingConflict,
+        create: onCreate,
+      },
+    },
+    // Reached only on the happy path, which these tests don't exercise.
+    stripe: {},
+  } as unknown as Context
+
+  return { context }
+}
+
+const input = {
+  workspaceId: "ws_openads",
+  tierId: "tier_gold",
+  interval: "Month" as const,
+  intervalCount: 1,
+  amount: 1900,
+  currency: "usd",
+}
+
+describe("tierPrice.create conflict handling", () => {
+  it("rejects with CONFLICT when an active price of the same shape already exists", async () => {
+    const { context } = createContext({ existingConflict: { id: "tier_price_existing" } })
+
+    await expect(tierPriceRouter.create.callable({ context })(input)).rejects.toHaveProperty(
+      "code",
+      "CONFLICT",
+    )
+  })
+
+  it("maps the partial-unique-index P2002 race to the same CONFLICT error", async () => {
+    // No pre-check conflict, but a concurrent submit wins the race and the
+    // `TierPrice_active_shape_key` index rejects this insert with P2002.
+    const { context } = createContext({
+      existingConflict: null,
+      onCreate: async () => {
+        throw p2002
+      },
+    })
+
+    await expect(tierPriceRouter.create.callable({ context })(input)).rejects.toHaveProperty(
+      "code",
+      "CONFLICT",
+    )
+  })
+})

--- a/packages/orpc/src/routers/tier-price.ts
+++ b/packages/orpc/src/routers/tier-price.ts
@@ -22,54 +22,43 @@ export const tierPriceRouter = {
         throw new ORPCError("NOT_FOUND", { message: "Tier not found." })
       }
 
-      // Check-then-create runs serializably so two concurrent submits can't
-      // both pass the check and mint duplicate active prices (and duplicate
-      // live Stripe Prices). The Stripe call stays outside the transaction —
-      // never hold a serializable transaction across a network round trip.
-      // The durable fix is a partial unique index, deferred until migrations
-      // are adopted.
-      const tierPrice = await db
-        .$transaction(
-          async tx => {
-            // Amount is intentionally not part of the uniqueness key — that's
-            // the field you change by archive-and-create.
-            const conflict = await tx.tierPrice.findFirst({
-              where: {
-                tierId: tier.id,
-                interval: input.interval,
-                intervalCount: input.intervalCount,
-                currency: input.currency,
-                isActive: true,
-              },
-            })
+      const conflictMessage =
+        "An active price already exists for this interval and currency. Archive it before creating a replacement."
 
-            if (conflict) {
-              throw new ORPCError("CONFLICT", {
-                message:
-                  "An active price already exists for this interval and currency. Archive it before creating a replacement.",
-              })
-            }
+      // Amount is intentionally not part of the uniqueness key — that's the
+      // field you change by archive-and-create. The pre-check gives a friendly
+      // error in the common sequential case; the partial unique index
+      // `TierPrice_active_shape_key` (one active row per shape) is the durable
+      // guard against the double-submit race, surfaced below as P2002.
+      const conflict = await db.tierPrice.findFirst({
+        where: {
+          tierId: tier.id,
+          interval: input.interval,
+          intervalCount: input.intervalCount,
+          currency: input.currency,
+          isActive: true,
+        },
+      })
 
-            return await tx.tierPrice.create({
-              data: {
-                tierId: tier.id,
-                interval: input.interval,
-                intervalCount: input.intervalCount,
-                amount: input.amount,
-                currency: input.currency,
-              },
-            })
+      if (conflict) {
+        throw new ORPCError("CONFLICT", { message: conflictMessage })
+      }
+
+      const tierPrice = await db.tierPrice
+        .create({
+          data: {
+            tierId: tier.id,
+            interval: input.interval,
+            intervalCount: input.intervalCount,
+            amount: input.amount,
+            currency: input.currency,
           },
-          { isolationLevel: "Serializable" },
-        )
+        })
         .catch(err => {
-          // P2034 = serialization failure: the concurrent submit won the race,
-          // so surface the same conflict error a sequential check would have.
-          if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2034") {
-            throw new ORPCError("CONFLICT", {
-              message:
-                "An active price already exists for this interval and currency. Archive it before creating a replacement.",
-            })
+          // The concurrent submit won the race past the pre-check; the unique
+          // index rejected this insert, so surface the same conflict error.
+          if (err instanceof Prisma.PrismaClientKnownRequestError && err.code === "P2002") {
+            throw new ORPCError("CONFLICT", { message: conflictMessage })
           }
           throw err
         })


### PR DESCRIPTION
Closes #22.

## Background

The "at most one active price per `(interval, intervalCount, currency)` shape" rule was enforced only by an app-level `findFirst` in `tierPrice.create` — racy by construction (a publisher double-clicking the create form could mint two active prices for the same shape, plus duplicate live Stripe Prices).

The issue assumed this required adopting Prisma migrations because "Prisma cannot express [a partial unique index] in the schema." That's **no longer true**: Prisma **7.4+** (this repo is on 7.8) supports partial/filtered indexes natively via a `where` argument behind the `partialIndexes` preview feature — so the index is expressible in the schema and applied by the existing `db:push`, no migrations adoption needed. Confirmed the simpler approach with the repo owner before implementing.

## Changes

- **`@openads/db`**
  - Enable the `partialIndexes` preview feature on the generator.
  - Add `@@unique([tierId, interval, intervalCount, currency], where: raw("\"isActive\""))` on `TierPrice`, mapped to `TierPrice_active_shape_key`. Amount is deliberately not in the key (changing it is archive + create-new); the partial `where` scopes uniqueness to active rows so archived/grandfathered prices don't collide.
- **`tierPrice.create`**: replace the Serializable check-then-create stopgap with a plain create guarded by the index. Keep the `findFirst` pre-check for the friendly error in the common sequential case, and map `P2002` (the double-submit race losing to the index) to the same `CONFLICT`.
- **Docs**: documented the enforcement in `AGENTS.md` (decision #10).

## Verification

- Applied to the dev DB via `bun run db:push --accept-data-loss` (after confirming 0 existing duplicate active shapes). Verified in Postgres:
  ```
  CREATE UNIQUE INDEX "TierPrice_active_shape_key" ON public."TierPrice"
    USING btree ("tierId","interval","intervalCount",currency) WHERE "isActive"
  ```
- New `tier-price.test.ts` covers both the pre-check conflict and the P2002-race → `CONFLICT` mapping.

## Test plan

- [x] `bun run check-types`
- [x] `bun run lint`
- [x] `bun test` (18 pass)
- [x] `db:push` applies the partial index; verified live in Postgres

## Note on workflow

This keeps the current `db:push` / no-migrations workflow (per `AGENTS.md`) rather than adopting Prisma migrations — the native partial-index support made migrations unnecessary for this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)